### PR TITLE
feat(backend): Update Go module path to full GitHub path

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"kiwi/internal/server"
-	"kiwi/internal/util"
-	"kiwi/pkg/logger"
-	"kiwi/pkg/logger/console"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/server"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/util"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger/console"
 
 	_ "github.com/lib/pq"
 )

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -8,17 +8,17 @@ import (
 	"syscall"
 	"time"
 
-	"kiwi/internal/queue"
-	"kiwi/internal/storage"
-	"kiwi/internal/util"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/queue"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/storage"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/util"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 
-	"kiwi/pkg/ai"
-	oai "kiwi/pkg/ai/ollama"
-	gai "kiwi/pkg/ai/openai"
-	"kiwi/pkg/logger"
-	"kiwi/pkg/logger/console"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	oai "github.com/OFFIS-RIT/kiwi/backend/pkg/ai/ollama"
+	gai "github.com/OFFIS-RIT/kiwi/backend/pkg/ai/openai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger/console"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,4 +1,4 @@
-module kiwi
+module github.com/OFFIS-RIT/kiwi/backend
 
 go 1.25
 

--- a/backend/internal/queue/handler.go
+++ b/backend/internal/queue/handler.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"kiwi/internal/db"
-	"kiwi/internal/storage"
-	"kiwi/internal/util"
-	"kiwi/pkg/logger"
-	graphstorage "kiwi/pkg/store/base"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/storage"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/util"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
+	graphstorage "github.com/OFFIS-RIT/kiwi/backend/pkg/store/base"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -22,18 +22,18 @@ import (
 	"github.com/pkoukk/tiktoken-go"
 	"github.com/rabbitmq/amqp091-go"
 
-	"kiwi/pkg/ai"
-	"kiwi/pkg/graph"
-	"kiwi/pkg/loader"
-	"kiwi/pkg/loader/audio"
-	"kiwi/pkg/loader/csv"
-	"kiwi/pkg/loader/doc"
-	"kiwi/pkg/loader/excel"
-	"kiwi/pkg/loader/image"
-	"kiwi/pkg/loader/ocr"
-	"kiwi/pkg/loader/pdf"
-	"kiwi/pkg/loader/pptx"
-	"kiwi/pkg/loader/s3"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/graph"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader/audio"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader/csv"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader/doc"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader/excel"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader/image"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader/ocr"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader/pdf"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader/pptx"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader/s3"
 )
 
 type QueueProjectFileMsg struct {
@@ -62,7 +62,7 @@ func ProcessIndexMessage(
 
 	q := db.New(conn)
 
-	s3L := s3.NewS3GraphFileLoaderWithClient("kiwi", s3Client)
+	s3L := s3.NewS3GraphFileLoaderWithClient("github.com/OFFIS-RIT/kiwi", s3Client)
 	files := make([]loader.GraphFile, 0)
 
 	for _, file := range *data.ProjectFiles {
@@ -215,7 +215,7 @@ func ProcessUpdateMessage(
 
 	q := db.New(conn)
 
-	s3L := s3.NewS3GraphFileLoaderWithClient("kiwi", s3Client)
+	s3L := s3.NewS3GraphFileLoaderWithClient("github.com/OFFIS-RIT/kiwi", s3Client)
 	files := make([]loader.GraphFile, 0)
 
 	for _, file := range *data.ProjectFiles {
@@ -444,7 +444,7 @@ func ProcessPreprocess(
 	noProcessingFiles := make([]loader.GraphFile, 0)
 	pageCount := 0
 	for _, upload := range *data.ProjectFiles {
-		s3L := s3.NewS3GraphFileLoaderWithClient("kiwi", s3Client)
+		s3L := s3.NewS3GraphFileLoaderWithClient("github.com/OFFIS-RIT/kiwi", s3Client)
 		ocrL := ocr.NewOCRGraphLoader(ocr.NewOCRGraphLoaderParams{
 			AIClient: aiClient,
 			Parallel: int(numParallel),
@@ -556,7 +556,7 @@ func ProcessPreprocess(
 
 			// Estimate work units based on file size
 			head, err := s3Client.HeadObject(ctx, &awss3.HeadObjectInput{
-				Bucket: aws.String("kiwi"),
+				Bucket: aws.String("github.com/OFFIS-RIT/kiwi"),
 				Key:    aws.String(upload.FileKey),
 			})
 			if err == nil && head.ContentLength != nil {
@@ -580,7 +580,7 @@ func ProcessPreprocess(
 			files = append(files, f)
 
 			head, err := s3Client.HeadObject(ctx, &awss3.HeadObjectInput{
-				Bucket: aws.String("kiwi"),
+				Bucket: aws.String("github.com/OFFIS-RIT/kiwi"),
 				Key:    aws.String(upload.FileKey),
 			})
 			if err == nil && head.ContentLength != nil {

--- a/backend/internal/queue/queue.go
+++ b/backend/internal/queue/queue.go
@@ -2,8 +2,8 @@ package queue
 
 import (
 	"fmt"
-	"kiwi/internal/util"
-	"kiwi/pkg/logger"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/util"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
 	"time"
 
 	"github.com/rabbitmq/amqp091-go"

--- a/backend/internal/server/middleware/context.go
+++ b/backend/internal/server/middleware/context.go
@@ -1,7 +1,7 @@
 package middleware
 
 import (
-	"kiwi/internal/util"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/util"
 
 	"github.com/MicahParks/keyfunc/v3"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -9,10 +9,10 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/rabbitmq/amqp091-go"
 
-	"kiwi/pkg/ai"
-	oai "kiwi/pkg/ai/ollama"
-	gai "kiwi/pkg/ai/openai"
-	"kiwi/pkg/logger"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	oai "github.com/OFFIS-RIT/kiwi/backend/pkg/ai/ollama"
+	gai "github.com/OFFIS-RIT/kiwi/backend/pkg/ai/openai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
 )
 
 type AppUser struct {

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -1,8 +1,8 @@
 package server
 
 import (
-	"kiwi/internal/server/middleware"
-	"kiwi/internal/server/routes"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/server/middleware"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/server/routes"
 
 	"github.com/labstack/echo/v4"
 )

--- a/backend/internal/server/routes/delete_groups.go
+++ b/backend/internal/server/routes/delete_groups.go
@@ -2,9 +2,9 @@ package routes
 
 import (
 	"fmt"
-	"kiwi/internal/db"
-	"kiwi/internal/server/middleware"
-	"kiwi/internal/storage"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/server/middleware"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/storage"
 	"net/http"
 
 	"slices"

--- a/backend/internal/server/routes/delete_projects.go
+++ b/backend/internal/server/routes/delete_projects.go
@@ -2,11 +2,11 @@ package routes
 
 import (
 	"fmt"
-	"kiwi/internal/db"
-	"kiwi/internal/queue"
-	"kiwi/internal/server/middleware"
-	"kiwi/internal/storage"
-	"kiwi/internal/util"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/queue"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/server/middleware"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/storage"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/util"
 	"net/http"
 
 	"github.com/labstack/echo/v4"

--- a/backend/internal/server/routes/get_groups.go
+++ b/backend/internal/server/routes/get_groups.go
@@ -1,8 +1,8 @@
 package routes
 
 import (
-	"kiwi/internal/db"
-	"kiwi/internal/server/middleware"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/server/middleware"
 	"net/http"
 
 	_ "github.com/go-playground/validator"

--- a/backend/internal/server/routes/get_projects.go
+++ b/backend/internal/server/routes/get_projects.go
@@ -3,10 +3,10 @@ package routes
 import (
 	"context"
 	"fmt"
-	"kiwi/internal/db"
-	"kiwi/internal/server/middleware"
-	"kiwi/internal/storage"
-	"kiwi/internal/util"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/server/middleware"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/storage"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/util"
 	"net/http"
 
 	_ "github.com/go-playground/validator"

--- a/backend/internal/server/routes/patch_groups.go
+++ b/backend/internal/server/routes/patch_groups.go
@@ -1,8 +1,8 @@
 package routes
 
 import (
-	"kiwi/internal/db"
-	"kiwi/internal/server/middleware"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/server/middleware"
 	"net/http"
 
 	"github.com/labstack/echo/v4"

--- a/backend/internal/server/routes/patch_projects.go
+++ b/backend/internal/server/routes/patch_projects.go
@@ -1,8 +1,8 @@
 package routes
 
 import (
-	"kiwi/internal/db"
-	"kiwi/internal/server/middleware"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/server/middleware"
 	"net/http"
 
 	"github.com/labstack/echo/v4"

--- a/backend/internal/server/routes/post_groups.go
+++ b/backend/internal/server/routes/post_groups.go
@@ -1,8 +1,8 @@
 package routes
 
 import (
-	"kiwi/internal/db"
-	"kiwi/internal/server/middleware"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/server/middleware"
 	"net/http"
 
 	_ "github.com/go-playground/validator"

--- a/backend/internal/server/routes/post_projects.go
+++ b/backend/internal/server/routes/post_projects.go
@@ -3,23 +3,23 @@ package routes
 import (
 	"encoding/json"
 	"fmt"
-	"kiwi/internal/db"
-	"kiwi/pkg/logger"
-	graphstorage "kiwi/pkg/store/base"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
+	graphstorage "github.com/OFFIS-RIT/kiwi/backend/pkg/store/base"
 
-	"kiwi/internal/queue"
-	"kiwi/internal/server/middleware"
-	"kiwi/internal/storage"
-	"kiwi/internal/util"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/queue"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/server/middleware"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/storage"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/util"
 	"net/http"
 	"regexp"
 	"strings"
 
 	"slices"
 
-	bqc "kiwi/pkg/query/base"
+	bqc "github.com/OFFIS-RIT/kiwi/backend/pkg/query/base"
 
-	"kiwi/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
 
 	_ "github.com/go-playground/validator"
 	"github.com/labstack/echo/v4"

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -9,11 +9,11 @@ import (
 	"syscall"
 	"time"
 
-	"kiwi/internal/queue"
-	mid "kiwi/internal/server/middleware"
-	"kiwi/internal/storage"
-	"kiwi/internal/util"
-	"kiwi/pkg/logger"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/queue"
+	mid "github.com/OFFIS-RIT/kiwi/backend/internal/server/middleware"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/storage"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/util"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
 
 	"github.com/MicahParks/keyfunc/v3"
 	"github.com/go-playground/validator"

--- a/backend/internal/storage/s3.go
+++ b/backend/internal/storage/s3.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"kiwi/internal/util"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/util"
 	"mime"
 	"net/url"
 	"strings"

--- a/backend/internal/timing/timing.go
+++ b/backend/internal/timing/timing.go
@@ -2,7 +2,7 @@ package timing
 
 import (
 	"context"
-	"kiwi/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )

--- a/backend/internal/util/env.go
+++ b/backend/internal/util/env.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"kiwi/pkg/logger"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
 	"os"
 	"strconv"
 

--- a/backend/pkg/ai/ai.go
+++ b/backend/pkg/ai/ai.go
@@ -3,7 +3,7 @@ package ai
 import (
 	"context"
 
-	"kiwi/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
 )
 
 // ToolHandler is a function that executes a tool call and returns its result.

--- a/backend/pkg/ai/dedupe.go
+++ b/backend/pkg/ai/dedupe.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	gUtil "kiwi/internal/util"
-	"kiwi/pkg/common"
+	gUtil "github.com/OFFIS-RIT/kiwi/backend/internal/util"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/common"
 )
 
 const DedupeBatchSize = 600

--- a/backend/pkg/ai/ollama/chat.go
+++ b/backend/pkg/ai/ollama/chat.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"strings"
 
-	"kiwi/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
 
 	"github.com/ollama/ollama/api"
 	"github.com/pkoukk/tiktoken-go"

--- a/backend/pkg/ai/ollama/embedding.go
+++ b/backend/pkg/ai/ollama/embedding.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/ollama/ollama/api"
-	"kiwi/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
 )
 
 const embeddingDimensions = 4096

--- a/backend/pkg/ai/ollama/image.go
+++ b/backend/pkg/ai/ollama/image.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 
-	"kiwi/pkg/ai"
-	"kiwi/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
 
 	"github.com/ollama/ollama/api"
 )

--- a/backend/pkg/ai/ollama/metrics.go
+++ b/backend/pkg/ai/ollama/metrics.go
@@ -3,7 +3,7 @@ package ollama
 import (
 	"math"
 
-	"kiwi/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
 )
 
 // ResetMetrics clears all accumulated token and timing metrics to zero.

--- a/backend/pkg/ai/ollama/ollama.go
+++ b/backend/pkg/ai/ollama/ollama.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"sync"
 
-	"kiwi/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
 
 	"github.com/ollama/ollama/api"
 )

--- a/backend/pkg/ai/openai/audio.go
+++ b/backend/pkg/ai/openai/audio.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"kiwi/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
 
 	"github.com/openai/openai-go/v3"
 )

--- a/backend/pkg/ai/openai/chat.go
+++ b/backend/pkg/ai/openai/chat.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"kiwi/pkg/ai"
-	"kiwi/pkg/logger"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/shared"

--- a/backend/pkg/ai/openai/embedding.go
+++ b/backend/pkg/ai/openai/embedding.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"kiwi/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/packages/param"

--- a/backend/pkg/ai/openai/image.go
+++ b/backend/pkg/ai/openai/image.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"kiwi/pkg/ai"
-	"kiwi/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
 
 	"github.com/openai/openai-go/v3"
 )

--- a/backend/pkg/ai/openai/metrics.go
+++ b/backend/pkg/ai/openai/metrics.go
@@ -3,7 +3,7 @@ package openai
 import (
 	"math"
 
-	"kiwi/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
 )
 
 // ResetMetrics clears all accumulated token and timing metrics to zero.

--- a/backend/pkg/ai/openai/openai.go
+++ b/backend/pkg/ai/openai/openai.go
@@ -3,7 +3,7 @@ package openai
 import (
 	"sync"
 
-	"kiwi/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"

--- a/backend/pkg/graph/dedupe.go
+++ b/backend/pkg/graph/dedupe.go
@@ -3,9 +3,9 @@ package graph
 import (
 	"context"
 	"fmt"
-	"kiwi/pkg/ai"
-	"kiwi/pkg/common"
-	"kiwi/pkg/logger"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/common"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
 	"strings"
 
 	_ "github.com/invopop/jsonschema"

--- a/backend/pkg/graph/entity_relation.go
+++ b/backend/pkg/graph/entity_relation.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"kiwi/pkg/ai"
-	"kiwi/pkg/common"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/common"
 )
 
 func generateDescription(

--- a/backend/pkg/graph/extract.go
+++ b/backend/pkg/graph/extract.go
@@ -7,8 +7,8 @@ import (
 
 	_ "github.com/invopop/jsonschema"
 
-	"kiwi/pkg/ai"
-	"kiwi/pkg/common"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/common"
 
 	gonanoid "github.com/matoous/go-nanoid/v2"
 )

--- a/backend/pkg/graph/graph.go
+++ b/backend/pkg/graph/graph.go
@@ -8,10 +8,10 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"kiwi/pkg/ai"
-	"kiwi/pkg/loader"
-	"kiwi/pkg/logger"
-	"kiwi/pkg/store"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/store"
 
 	"golang.org/x/sync/errgroup"
 )

--- a/backend/pkg/graph/merge.go
+++ b/backend/pkg/graph/merge.go
@@ -1,7 +1,7 @@
 package graph
 
 import (
-	"kiwi/pkg/common"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/common"
 )
 
 func mergeEntitiesAndRelations(

--- a/backend/pkg/graph/process.go
+++ b/backend/pkg/graph/process.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"sync"
 
-	gUtil "kiwi/internal/util"
-	"kiwi/pkg/ai"
-	"kiwi/pkg/common"
-	"kiwi/pkg/loader"
+	gUtil "github.com/OFFIS-RIT/kiwi/backend/internal/util"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/common"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
 
 	"golang.org/x/sync/errgroup"
 )

--- a/backend/pkg/graph/unit.go
+++ b/backend/pkg/graph/unit.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"unicode"
 
-	"kiwi/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
 
 	gonanoid "github.com/matoous/go-nanoid/v2"
 	"github.com/pkoukk/tiktoken-go"

--- a/backend/pkg/graph/unit_test.go
+++ b/backend/pkg/graph/unit_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"kiwi/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
 )
 
 func TestSplitIntoSentences(t *testing.T) {

--- a/backend/pkg/loader/audio/audio.go
+++ b/backend/pkg/loader/audio/audio.go
@@ -3,8 +3,8 @@ package audio
 import (
 	"context"
 
-	"kiwi/pkg/ai"
-	"kiwi/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
 )
 
 // AudioGraphLoader loads audio files and transcribes them to text using an AI client.

--- a/backend/pkg/loader/csv/csv.go
+++ b/backend/pkg/loader/csv/csv.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"kiwi/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
 
 	"golang.org/x/sync/singleflight"
 )

--- a/backend/pkg/loader/doc/doc.go
+++ b/backend/pkg/loader/doc/doc.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"sync"
 
-	"kiwi/pkg/loader"
-	"kiwi/pkg/loader/ocr"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader/ocr"
 
 	"golang.org/x/sync/singleflight"
 )

--- a/backend/pkg/loader/excel/excel.go
+++ b/backend/pkg/loader/excel/excel.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"sync"
 
-	"kiwi/pkg/loader"
-	"kiwi/pkg/loader/csv"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader/csv"
 
 	"golang.org/x/sync/singleflight"
 )

--- a/backend/pkg/loader/image/image.go
+++ b/backend/pkg/loader/image/image.go
@@ -5,8 +5,8 @@ import (
 	"encoding/base64"
 	"io"
 
-	"kiwi/pkg/ai"
-	"kiwi/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
 )
 
 // ImageGraphLoader loads image files and generates text descriptions using an AI vision model.

--- a/backend/pkg/loader/io/io.go
+++ b/backend/pkg/loader/io/io.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"kiwi/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
 
 	"golang.org/x/sync/singleflight"
 )

--- a/backend/pkg/loader/ocr/ocr.go
+++ b/backend/pkg/loader/ocr/ocr.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"kiwi/pkg/ai"
-	"kiwi/pkg/loader"
-	"kiwi/pkg/logger"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
 	"strings"
 	"sync"
 

--- a/backend/pkg/loader/pdf/pdf.go
+++ b/backend/pkg/loader/pdf/pdf.go
@@ -3,8 +3,8 @@ package pdf
 import (
 	"context"
 	"encoding/base64"
-	"kiwi/pkg/loader"
-	"kiwi/pkg/loader/ocr"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader/ocr"
 	"sync"
 
 	"golang.org/x/sync/singleflight"

--- a/backend/pkg/loader/pptx/pptx.go
+++ b/backend/pkg/loader/pptx/pptx.go
@@ -3,8 +3,8 @@ package pptx
 import (
 	"context"
 	"encoding/base64"
-	"kiwi/pkg/loader"
-	"kiwi/pkg/loader/ocr"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader/ocr"
 	"sync"
 
 	"golang.org/x/sync/singleflight"

--- a/backend/pkg/loader/s3/s3.go
+++ b/backend/pkg/loader/s3/s3.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"golang.org/x/sync/singleflight"
 
-	"kiwi/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
 )
 
 func getBase64Prefix(filePath string) string {

--- a/backend/pkg/loader/util.go
+++ b/backend/pkg/loader/util.go
@@ -21,7 +21,7 @@ func TransformDocToPdf(input []byte, ext string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("nanoid: %w", err)
 	}
-	tmpDir := filepath.Join(os.TempDir(), "kiwi-ocr-"+id)
+	tmpDir := filepath.Join(os.TempDir(), "github.com/OFFIS-RIT/kiwi-ocr-"+id)
 	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir tmp: %w", err)
 	}
@@ -73,7 +73,7 @@ func TransformDocToImages(input []byte, ext string) ([][]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("nanoid: %w", err)
 	}
-	tmpDir := filepath.Join(os.TempDir(), "kiwi-ocr-"+id)
+	tmpDir := filepath.Join(os.TempDir(), "github.com/OFFIS-RIT/kiwi-ocr-"+id)
 	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir tmp: %w", err)
 	}
@@ -125,7 +125,7 @@ func TransformPdfToImages(input []byte) ([][]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("nanoid: %w", err)
 	}
-	tmpDir := filepath.Join(os.TempDir(), "kiwi-ocr-"+id)
+	tmpDir := filepath.Join(os.TempDir(), "github.com/OFFIS-RIT/kiwi-ocr-"+id)
 	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir tmp: %w", err)
 	}
@@ -195,7 +195,7 @@ func CountPDFPages(input []byte) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("nanoid: %w", err)
 	}
-	tmpDir := filepath.Join(os.TempDir(), "kiwi-count-"+id)
+	tmpDir := filepath.Join(os.TempDir(), "github.com/OFFIS-RIT/kiwi-count-"+id)
 	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
 		return 0, fmt.Errorf("mkdir tmp: %w", err)
 	}
@@ -259,7 +259,7 @@ func TransformExcelToCsv(input []byte, ext string) (map[string][]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("nanoid: %w", err)
 	}
-	tmpDir := filepath.Join(os.TempDir(), "kiwi-excel-"+id)
+	tmpDir := filepath.Join(os.TempDir(), "github.com/OFFIS-RIT/kiwi-excel-"+id)
 	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir tmp: %w", err)
 	}

--- a/backend/pkg/loader/web/web.go
+++ b/backend/pkg/loader/web/web.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"sync"
 
-	"kiwi/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
 
 	"codeberg.org/readeck/go-readability/v2"
 	"golang.org/x/sync/singleflight"

--- a/backend/pkg/query/base/base.go
+++ b/backend/pkg/query/base/base.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"kiwi/pkg/ai"
-	"kiwi/pkg/store"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/store"
 )
 
 type queryOptions struct {

--- a/backend/pkg/query/base/global.go
+++ b/backend/pkg/query/base/global.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"kiwi/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
 )
 
 // QueryGlobal performs a global query across the entire knowledge graph. Unlike

--- a/backend/pkg/query/base/local.go
+++ b/backend/pkg/query/base/local.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"kiwi/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
 )
 
 // QueryLocal performs a local query against the knowledge graph. It retrieves

--- a/backend/pkg/query/base/tools.go
+++ b/backend/pkg/query/base/tools.go
@@ -3,7 +3,7 @@ package base
 import (
 	"context"
 
-	"kiwi/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
 )
 
 // QueryTool performs a query with access to external tools. The AI can invoke

--- a/backend/pkg/query/query.go
+++ b/backend/pkg/query/query.go
@@ -3,7 +3,7 @@ package query
 import (
 	"context"
 
-	"kiwi/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
 )
 
 // GraphQueryClient defines the interface for querying knowledge graphs using AI.

--- a/backend/pkg/store/base/dedupe.go
+++ b/backend/pkg/store/base/dedupe.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"strings"
 
-	"kiwi/internal/db"
-	"kiwi/pkg/ai"
-	"kiwi/pkg/common"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/common"
 )
 
 // entityPair represents two potentially duplicate entities

--- a/backend/pkg/store/base/description.go
+++ b/backend/pkg/store/base/description.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"strings"
 
-	"kiwi/internal/db"
-	"kiwi/pkg/ai"
-	"kiwi/pkg/loader"
-	"kiwi/pkg/logger"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
 
 	"github.com/pgvector/pgvector-go"
 	"golang.org/x/sync/errgroup"

--- a/backend/pkg/store/base/entity.go
+++ b/backend/pkg/store/base/entity.go
@@ -2,10 +2,10 @@ package base
 
 import (
 	"context"
-	"kiwi/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
 	"strconv"
 
-	"kiwi/pkg/common"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/common"
 
 	"github.com/pgvector/pgvector-go"
 	"golang.org/x/sync/errgroup"

--- a/backend/pkg/store/base/graph.go
+++ b/backend/pkg/store/base/graph.go
@@ -2,11 +2,11 @@ package base
 
 import (
 	"context"
-	"kiwi/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
 	"strconv"
 	"sync"
 
-	"kiwi/pkg/common"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/common"
 
 	"github.com/jackc/pgx/v5"
 	"golang.org/x/sync/errgroup"

--- a/backend/pkg/store/base/graphstorage.go
+++ b/backend/pkg/store/base/graphstorage.go
@@ -2,12 +2,12 @@ package base
 
 import (
 	"context"
-	"kiwi/internal/util"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/util"
 	"sync"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
-	"kiwi/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
 )
 
 type pgxIConn interface {

--- a/backend/pkg/store/base/progress.go
+++ b/backend/pkg/store/base/progress.go
@@ -3,7 +3,7 @@ package base
 import (
 	"context"
 
-	"kiwi/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
 )
 
 // UpdateProjectProcessStep updates the current step of project processing.

--- a/backend/pkg/store/base/query.go
+++ b/backend/pkg/store/base/query.go
@@ -3,8 +3,8 @@ package base
 import (
 	"context"
 	"fmt"
-	"kiwi/internal/db"
-	"kiwi/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
 	"slices"
 	"strconv"
 	"strings"

--- a/backend/pkg/store/base/relationship.go
+++ b/backend/pkg/store/base/relationship.go
@@ -3,11 +3,11 @@ package base
 import (
 	"context"
 	"fmt"
-	"kiwi/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
 	"slices"
 	"strconv"
 
-	"kiwi/pkg/common"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/common"
 
 	"github.com/pgvector/pgvector-go"
 	"golang.org/x/sync/errgroup"

--- a/backend/pkg/store/base/tools.go
+++ b/backend/pkg/store/base/tools.go
@@ -5,11 +5,11 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"kiwi/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
 	"strings"
 
-	"kiwi/pkg/ai"
-	"kiwi/pkg/logger"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgvector/pgvector-go"

--- a/backend/pkg/store/base/unit.go
+++ b/backend/pkg/store/base/unit.go
@@ -2,11 +2,11 @@ package base
 
 import (
 	"context"
-	"kiwi/internal/db"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
 	"strconv"
 	"strings"
 
-	"kiwi/pkg/common"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/common"
 
 	gonanoid "github.com/matoous/go-nanoid/v2"
 )

--- a/backend/pkg/store/storage.go
+++ b/backend/pkg/store/storage.go
@@ -3,9 +3,9 @@ package store
 import (
 	"context"
 
-	"kiwi/pkg/ai"
-	"kiwi/pkg/common"
-	"kiwi/pkg/loader"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/common"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/loader"
 )
 
 // GraphStorage defines the interface for persisting and querying knowledge graphs.


### PR DESCRIPTION
## Summary

Update the Go module name from `kiwi` to `github.com/OFFIS-RIT/kiwi/backend` to use a proper importable module path following Go conventions.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Updated `go.mod` module declaration from `kiwi` to `github.com/OFFIS-RIT/kiwi/backend`
- Updated all internal import statements across 68 files to use the new module path

## Related Issues

Closes #4

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

N/A - no UI changes