### PR TITLE
chore: Add automated release changelog configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,32 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+      - "good first issue"
+      - "Good for newcomers"
+      - help wanted
+      - open issues
+      - question
+  categories:
+    - title: 🚀 Features
+      labels:
+        - enhancement
+        - frontend
+        - backend
+        - auth
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: 📚 Documentation
+      labels:
+        - documentation
+    - title: 🔧 CI/CD
+      labels:
+        - ci
+        - github_actions
+        - docker
+    - title: ⬆️ Dependencies
+      labels:
+        - dependencies


### PR DESCRIPTION
## Summary

Add  configuration to enable GitHub's automated release changelog generation. Changes will be automatically categorized in release notes based on labels.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- Added  with changelog configuration
- Configured categories: Features, Bug Fixes, Documentation, CI/CD, Dependencies
- Configured exclusions for duplicate, invalid, wontfix, and other labels

## Related Issues

Closes #20

## Testing

- [x] I have tested these changes locally (file syntax verified)
- [ ] I have added/updated tests as appropriate (not applicable)
- [ ] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed (not applicable)
- [ ] I have run  if SQL queries were modified (not applicable)
- [ ] I have updated barrel exports if components were added (not applicable)