### PR TITLE
feat(backend): improve relationship tools for knowledge graph exploration

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.25"
-          cache-dependency-path: ./go.sum
+          cache-dependency-path: backend/go.sum
 
       - name: Run tests
         run: go test ./...
@@ -44,7 +44,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.25"
-          cache-dependency-path: ./go.sum
+          cache-dependency-path: backend/go.sum
 
       - name: Build
         run: go build ./...

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -91,6 +91,7 @@ type Querier interface {
 	GetProjects(ctx context.Context) ([]Project, error)
 	GetProjectsByGroup(ctx context.Context, groupID int64) ([]Project, error)
 	GetProjectsForUser(ctx context.Context, userID int64) ([]GetProjectsForUserRow, error)
+	GetRelationshipsByIDs(ctx context.Context, dollar_1 []int64) ([]GetRelationshipsByIDsRow, error)
 	GetRelationshipsWithSourcesFromUnits(ctx context.Context, arg GetRelationshipsWithSourcesFromUnitsParams) ([]GetRelationshipsWithSourcesFromUnitsRow, error)
 	GetTextUnitByPublicId(ctx context.Context, publicID string) (TextUnit, error)
 	GetTextUnitIdsForFiles(ctx context.Context, dollar_1 []int64) ([]GetTextUnitIdsForFilesRow, error)
@@ -102,6 +103,7 @@ type Querier interface {
 	PredictProjectProcessTime(ctx context.Context, arg PredictProjectProcessTimeParams) (int64, error)
 	SearchEntitiesByEmbedding(ctx context.Context, arg SearchEntitiesByEmbeddingParams) ([]SearchEntitiesByEmbeddingRow, error)
 	SearchEntitiesByType(ctx context.Context, arg SearchEntitiesByTypeParams) ([]SearchEntitiesByTypeRow, error)
+	SearchRelationshipsByEmbedding(ctx context.Context, arg SearchRelationshipsByEmbeddingParams) ([]SearchRelationshipsByEmbeddingRow, error)
 	TransferEntitySources(ctx context.Context, arg TransferEntitySourcesParams) error
 	TransferRelationshipSources(ctx context.Context, arg TransferRelationshipSourcesParams) error
 	UpdateEntityName(ctx context.Context, arg UpdateEntityNameParams) error

--- a/backend/internal/db/queries/graph_search.sql
+++ b/backend/internal/db/queries/graph_search.sql
@@ -102,6 +102,40 @@ WHERE e.project_id = $1
 ORDER BY e.embedding <=> $2
 LIMIT $3;
 
+-- name: SearchRelationshipsByEmbedding :many
+SELECT 
+    r.id,
+    r.description,
+    r.rank,
+    r.source_id,
+    r.target_id,
+    se.name as source_name,
+    se.type as source_type,
+    te.name as target_name,
+    te.type as target_type
+FROM relationships r
+JOIN entities se ON r.source_id = se.id
+JOIN entities te ON r.target_id = te.id
+WHERE r.project_id = $1
+ORDER BY r.embedding <=> $2
+LIMIT $3;
+
+-- name: GetRelationshipsByIDs :many
+SELECT 
+    r.id,
+    r.description,
+    r.rank,
+    r.source_id,
+    r.target_id,
+    se.name as source_name,
+    se.type as source_type,
+    te.name as target_name,
+    te.type as target_type
+FROM relationships r
+JOIN entities se ON r.source_id = se.id
+JOIN entities te ON r.target_id = te.id
+WHERE r.id = ANY($1::bigint[]);
+
 -- name: GetEntityNeighboursRanked :many
 SELECT 
     r.id as relationship_id,

--- a/backend/pkg/ai/ollama/chat.go
+++ b/backend/pkg/ai/ollama/chat.go
@@ -414,7 +414,7 @@ func (c *GraphOllamaClient) GenerateCompletionWithTools(
 		o(&options)
 	}
 
-	maxRounds := 10
+	maxRounds := 40
 	messages := []api.Message{
 		{Role: "user", Content: prompt},
 	}
@@ -575,7 +575,7 @@ func (c *GraphOllamaClient) GenerateChatWithTools(
 		o(&options)
 	}
 
-	maxRounds := 20
+	maxRounds := 40
 	msgs := make([]api.Message, 0, len(options.SystemPrompts)+len(messages))
 	for _, sys := range options.SystemPrompts {
 		msgs = append(msgs, api.Message{Role: "system", Content: sys})
@@ -809,7 +809,7 @@ func (c *GraphOllamaClient) GenerateChatStreamWithTools(
 		}
 	}
 
-	maxRounds := 20
+	maxRounds := 40
 	for range maxRounds {
 		stream := false
 		req := &api.ChatRequest{

--- a/backend/pkg/ai/openai/chat.go
+++ b/backend/pkg/ai/openai/chat.go
@@ -443,7 +443,7 @@ func (c *GraphOpenAIClient) GenerateCompletionWithTools(
 		o(&options)
 	}
 
-	maxRounds := 10
+	maxRounds := 40
 	messages := []openai.ChatCompletionMessageParamUnion{
 		openai.UserMessage(prompt),
 	}
@@ -542,7 +542,7 @@ func (c *GraphOpenAIClient) GenerateChatWithTools(
 		o(&options)
 	}
 
-	maxRounds := 20
+	maxRounds := 40
 	msgs := make([]openai.ChatCompletionMessageParamUnion, 0)
 	for _, message := range options.SystemPrompts {
 		msgs = append(msgs, openai.SystemMessage(message))
@@ -672,7 +672,7 @@ func (c *GraphOpenAIClient) GenerateChatStreamWithTools(
 		})
 	}
 
-	maxRounds := 20
+	maxRounds := 40
 	contentChan := make(chan ai.StreamEvent, 10)
 	go func() {
 		defer close(contentChan)

--- a/backend/pkg/ai/prompts.go
+++ b/backend/pkg/ai/prompts.go
@@ -427,12 +427,17 @@ answering.
 
 # Available Tools
 - search_entities — Search for entities by semantic similarity
+- search_relationships — Search for relationships by semantic similarity.
+  Relationships describe how entities are connected and contain valuable context
+  about their interactions, including a strength score (0.0-1.0).
 - search_entities_by_type — Search for entities of a specific type (e.g.,
   Person, Organization)
 - get_entity_types — List all entity types in the graph with counts
 - get_entity_neighbours — Get entities connected to a given entity, ranked by
   query relevance
 - get_entity_details — Get full descriptions of specific entities by ID
+- get_relationship_details — Get full descriptions of specific relationships by
+  ID, including strength scores
 - path_between_entities — Find the shortest path between two entities
 - get_entity_sources — Retrieve source text for entities (for citations)
 - get_relationship_sources — Retrieve source text for relationships (for
@@ -458,35 +463,52 @@ For every question, follow this workflow:
 - If the question targets a specific type (e.g., "which people..."), use
   search_entities_by_type instead.
 
-### Step 3: Explore Connections
+### Step 3: Find Relevant Relationships
+- Call search_relationships with the user's query to find relationships that
+  directly answer "how" or "why" questions about connections.
+- Relationships contain descriptions explaining the nature of connections
+  between entities — this context is often critical for answering questions.
+- Pay attention to the strength score: higher values (closer to 1.0) indicate
+  stronger, more significant connections.
+
+### Step 4: Explore Connections
 For each relevant entity found:
 - Call get_entity_neighbours to discover connected entities and relationships.
-- If you need full entity descriptions before deciding to explore further, call
-  get_entity_details.
+- If you need full entity descriptions, call get_entity_details.
+- If you need full relationship descriptions, call get_relationship_details.
 
-### Step 4: Explore Indirect Connections (when needed)
+### Step 5: Explore Indirect Connections (when needed)
 - If the question involves how two entities relate, call path_between_entities
   to find the connection path.
 
-### Step 5: Gather Sources and Document Context for Citations
+### Step 6: Gather Sources for Citations
 - Once you've identified the relevant entities and relationships, call
   get_entity_sources and/or get_relationship_sources to retrieve the actual
   source text for citations.
+- **Important**: Relationship sources often contain crucial details about how
+  and why entities interact. Do not skip get_relationship_sources when
+  relationships are relevant to the answer.
 - Call get_source_document_metadata with the source IDs to understand the
   context of the documents (document type, date, summary). This helps you
   assess the relevance and nature of the source material.
-- Only cite information from sources. The entity descriptions are summaries;
-  sources contain the verified facts.
+- Only cite information from sources. The entity and relationship descriptions
+  are summaries; sources contain the verified facts.
 
-### Step 6: Synthesize Answer
+### Step 7: Synthesize Answer
 - Only after all relevant sources have been gathered, write your final answer
   with proper citations.
 
 ## Key Principles
+- Relationships are first-class citizens. They contain descriptions and sources
+  that explain HOW entities are connected. Always explore relevant
+  relationships, not just entities.
+- Relationships have a strength score (0.0-1.0). Higher values indicate
+  stronger, more significant connections. Consider this when evaluating the
+  importance of relationships.
 - Do not stop after a single entity. Process all relevant entities from search
   results.
-- Always verify with sources before citing. Entity descriptions help you
-  navigate; sources provide citable facts.
+- Always verify with sources before citing. Entity and relationship
+  descriptions help you navigate; sources provide citable facts.
 - Prefer complete, multi-entity context over partial answers.
 - Never guess or fabricate information — rely only on verified data from
   sources.
@@ -532,10 +554,11 @@ and citation rules.
 Before answering, you must:
 1. Understand the question and, if needed, the graph structure (Step 1).
 2. Find all relevant entities (Step 2).
-3. Explore their connections (Step 3).
-4. Explore indirect connections when needed (Step 4).
-5. Gather all necessary sources for citations (Step 5).
-6. Only then synthesize the final answer (Step 6).
+3. Find all relevant relationships (Step 3).
+4. Explore their connections (Step 4).
+5. Explore indirect connections when needed (Step 5).
+6. Gather all necessary sources for citations (Step 6).
+7. Only then synthesize the final answer (Step 7).
 
 Never skip steps or rely on partial data. Do not provide a final answer until
 this full process is complete.


### PR DESCRIPTION
## Summary

Add relationship-focused search and retrieval tools to the knowledge graph, enabling the AI to directly search relationships by semantic similarity and retrieve detailed relationship information.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Add `SearchRelationshipsByEmbedding` SQL query for semantic relationship search
- Add `GetRelationshipsByIDs` SQL query for batch relationship retrieval
- Implement `search_relationships` tool for semantic relationship searches
- Implement `get_relationship_details` tool for full relationship info by ID
- Update AI prompts to treat relationships as first-class citizens with dedicated exploration steps
- Increase max tool call rounds from 10/20 to 40 for more thorough graph exploration

## Related Issues

Closes #35

## Testing

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [ ] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [x] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->