### PR TITLE
fix(backend): source id resolution

### DIFF
--- a/backend/internal/util/ids_test.go
+++ b/backend/internal/util/ids_test.go
@@ -145,6 +145,52 @@ func TestNormalizeIDs(t *testing.T) {
 			in:   "One. [id] [[id]]. Two. [id] [[other id]].",
 			want: "One. [[id]]. Two. [[id]] [[other id]].",
 		},
+		// Malformed IDs with prefixes from LLM
+		{
+			name: "MalformedCommaPrefix",
+			in:   "Reference: [[LEHR,sGvgBXbBcVCjBIKCLS2Os]]",
+			want: "Reference: [[sGvgBXbBcVCjBIKCLS2Os]]",
+		},
+		{
+			name: "MalformedMultipleCommaPrefixes",
+			in:   "Reference: [[LEHR,TIGER,sGvgBXbBcVCjBIKCLS2Os]]",
+			want: "Reference: [[sGvgBXbBcVCjBIKCLS2Os]]",
+		},
+		{
+			name: "MalformedSemicolonPrefix",
+			in:   "Reference: [[PREFIX;abc123xyz]]",
+			want: "Reference: [[abc123xyz]]",
+		},
+		{
+			name: "MalformedPipePrefix",
+			in:   "Reference: [[TYPE|abc123xyz]]",
+			want: "Reference: [[abc123xyz]]",
+		},
+		{
+			name: "MalformedColonPrefix",
+			in:   "Reference: [[DOC:abc123xyz]]",
+			want: "Reference: [[abc123xyz]]",
+		},
+		{
+			name: "MalformedMixedSeparators",
+			in:   "Reference: [[A,B;C|abc123xyz]]",
+			want: "Reference: [[abc123xyz]]",
+		},
+		{
+			name: "MalformedWithSpaces",
+			in:   "Reference: [[PREFIX, abc123xyz ]]",
+			want: "Reference: [[abc123xyz]]",
+		},
+		{
+			name: "MalformedMultipleIDs",
+			in:   "See [[LEHR,id1]] and [[TIGER,id2]]",
+			want: "See [[id1]] and [[id2]]",
+		},
+		{
+			name: "ValidIDNoChange",
+			in:   "Valid: [[sGvgBXbBcVCjBIKCLS2Os]]",
+			want: "Valid: [[sGvgBXbBcVCjBIKCLS2Os]]",
+		},
 	}
 
 	for _, tc := range tests {
@@ -154,7 +200,6 @@ func TestNormalizeIDs(t *testing.T) {
 				t.Fatalf("NormalizeIDs(%q)\nwant: %q\ngot:  %q",
 					tc.in, tc.want, got)
 			}
-			// Idempotence: applying twice yields the same result.
 			twice := NormalizeIDs(got)
 			if twice != got {
 				t.Fatalf("NormalizeIDs not idempotent for %q:\nfirst:  %q\nsecond: %q",


### PR DESCRIPTION
## Summary

Fixes malformed IDs with prefixes (like `[[LEHR,sGvgBXbBcVCjBIKCLS2Os]]`) generated by LLMs by extracting the last ID segment when comma/semicolon/pipe/colon separators are present.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Added `rePrefixedID` and `idSepSplitter` regex patterns to detect malformed IDs with separators
- Added `extractLastIDSegment` function to extract the last ID segment from malformed IDs
- Updated `NormalizeIDs` to call `extractLastIDSegment` for processing
- Added comprehensive tests for malformed ID cases (comma, semicolon, pipe, colon separators)

## Related Issues

Closes #37

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)