### PR TITLE
chore: add .opencode/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 #cursor
 .cursor/
 
+# opencode
+.opencode/
+
 # vscode
 .vscode/
 


### PR DESCRIPTION
## Summary

Add `.opencode/` directory to `.gitignore` to prevent user-specific OpenCode AI tool configurations from being committed to the repository.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI/CD or infrastructure change

## Changes Made

- Added `.opencode/` to `.gitignore` alongside similar editor/tool directories (`.cursor/`, `.vscode/`)

## Related Issues

Closes #41

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

N/A - configuration file change only