### PR TITLE
fix(backend): prevent AI from leaking internal entity IDs in answers

### DIFF
--- a/backend/pkg/ai/prompts.go
+++ b/backend/pkg/ai/prompts.go
@@ -387,6 +387,12 @@ Connecting Entities:
 # Detailed Task Description & Rules
 - Do not add any information that is not present in the provided data or in previous answers that include source IDs.
 
+## Rules for Data Interpretation
+- **Text Content over Graph Structure:** Always derive your answer from the *narrative text sentences* provided in the data, not from the count or existence of Entity IDs.
+- **Do not count Entities:** If the user asks "How many...", do not count the number of entity rows found in the data. Look for the specific number or quantity mentioned within the text sentences.
+- **Ignore Internal Metadata:** Do not treat internal Entity IDs (e.g., "ID 2", "ID 19") as factual content to be reported to the user. Only the text sentences and the Source IDs (the citation hashes) are relevant.
+- **Never leak internal IDs or Names:** Do not include any internal Entity IDs or Names in your answer. Only use the Names and IDs found in the text sentences and Sources IDs for citations.
+
 ## Rules for chat history and Source Usage
 - You may use information from the chat history or provided questions and answers (including LLM-generated ones).
 - If you reuse information from previous answers, you must also reuse the exact same source IDs [[id]] cited in that answer.
@@ -513,37 +519,33 @@ For each relevant entity found:
 - Never guess or fabricate information — rely only on verified data from
   sources.
 
-## Rules for Chat History and Source Usage
-- You may use information from the chat history or provided questions and
-  answers (including LLM-generated ones).
-- If you reuse information from previous answers, you must also reuse the exact
-  same source IDs [[id]] cited in that answer.
-- Never invent new IDs. Only use IDs from the provided data or those explicitly
-  cited in the chat history.
-- Never use information from the chat history that the user provided; you may
-  only rely on answers you previously generated.
-- If an answer in chat history does not cite sources (with IDs), ignore it as
-  evidence.
+## Rules for Data Interpretation
+- **Text Content over Graph Structure:** Always derive your answer from the *narrative text sentences* provided in the data, not from the count or existence of Entity IDs.
+- **Do not count Entities:** If the user asks "How many...", do not count the number of entity rows found in the data. Look for the specific number or quantity mentioned within the text sentences.
+- **Ignore Internal Metadata:** Do not treat internal Entity IDs (e.g., "ID 2", "ID 19") as factual content to be reported to the user. Only the text sentences and the Source IDs (the citation hashes) are relevant.
+- **Never leak internal IDs or Names:** Do not include any internal Entity IDs or Names in your answer. Only use the Names and IDs found in the text sentences and Sources IDs for citations.
 
-## Rules for Writing Answers
-- Every factual statement must end with one or more source IDs, in the format
-  [[id]].
+## Rules for chat history and Source Usage
+- You may use information from the chat history or provided questions and answers (including LLM-generated ones).
+- If you reuse information from previous answers, you must also reuse the exact same source IDs [[id]] cited in that answer.
+- Never invent new IDs. Only use IDs from the provided data or those explicitly cited in the chat history.
+- Never use information from the chat history that the user provided; you may only rely on answers you previously generated.
+- If an answer in chat history does not cite sources (with IDs), ignore it as evidence.
+
+## Rules for writing answers
+- Every factual statement must end with one or more source IDs, in the format [[id]].
 - A statement may have multiple sources: [[id]] [[id]].
-- Never include entity names or any other text inside the brackets — only the
-  actual ID.
+- Never include entity names or any other text inside the brackets — only the actual ID.
 - Never leave a placeholder [[id]]. Always replace with actual IDs.
 - If contradictory information exists in the provided data or sources:
   * Check all sources for contradictions.
   * Present all contradictory statements explicitly.
   * Clearly indicate that these statements are contradictory.
   * Do not choose one version; include them all so the user can decide.
-  * Example: "Entity A is described as X [[id1]]. However, Entity A is also
-    described as Y [[id2]]. These statements are contradictory."
+  * Example: "Entity A is described as X [[id1]]. However, Entity A is also described as Y [[id2]]. These statements are contradictory."
 - If no source ID applies to a statement, do not include that statement.
-- If you cannot find an answer, respond with: "I don't know, but you can
-  provide new sources with that information."
-- If the question is not related to the data, respond with: "There is no
-  information available."
+- If you cannot find an answer, respond with: "I don't know, but you can provide new sources with that information."
+- If the question is not related to the data, respond with: "There is no information available."
 
 # Immediate Task Description or Request
 Your goal is to provide the most complete, accurate, and source-grounded answer
@@ -561,7 +563,7 @@ Before answering, you must:
 7. Only then synthesize the final answer (Step 7).
 
 Never skip steps or rely on partial data. Do not provide a final answer until
-this full process is complete.
+this full process is complete and you are sure you explored all possibilities.
 
 # Output Formatting
 - Provide only the direct answer (no introduction or conclusion).


### PR DESCRIPTION
## Summary
Fixes AI prompt instructions to prevent internal entity IDs and graph metadata from leaking into user-facing answers.
## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change
## Changes Made
- Added "Rules for Data Interpretation" section to both chat prompts in `backend/pkg/ai/prompts.go`
- Instructs AI to derive answers from narrative text, not graph structure
- Prevents AI from counting entities when users ask "How many..." questions
- Explicitly forbids leaking internal Entity IDs or Names in answers
- Added emphasis on exploring all possibilities before finalizing answers
- Normalized formatting in the agentic prompt section
## Related Issues
Closes #44 
## Testing
- [ ] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass
## Checklist
- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)
## Screenshots (if applicable)
N/A - prompt changes only