### PR TITLE
fix(ci): use explicit cache for Go modules in backend workflow

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -24,7 +24,17 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.25"
-          cache-dependency-path: backend/go.sum
+          cache: false
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ hashFiles('backend/go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-
 
       - name: Run tests
         run: go test ./...
@@ -38,13 +48,23 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           go-version: "1.25"
-          cache-dependency-path: backend/go.sum
+          cache: false
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ hashFiles('backend/go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-
 
       - name: Build
         run: go build ./...


### PR DESCRIPTION
## Summary
- Fix Go module caching not working in backend CI workflow
- Replace `actions/setup-go` built-in cache with explicit `actions/cache@v4`
- Update `actions/checkout` to v6 in build job
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
## Changes Made
- Disabled built-in cache in `actions/setup-go` (`cache: false`)
- Added explicit `actions/cache@v4` with proper paths:
  - `~/go/pkg/mod` - Go module cache
  - `~/.cache/go-build` - Go build cache
- Updated `actions/checkout` from v4 to v6 in the build job
- Applied changes to both `test` and `build` jobs
## Related Issues
Closes #46
## Testing
- [ ] CI workflow runs successfully with cache hits on subsequent runs
## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes