### PR TITLE
ci: remove deployment steps for testing purposes

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -99,23 +99,3 @@ jobs:
           tags: ${{ env.IMAGE_PREFIX }}/auth:${{ env.IMAGE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    environment: staging
-
-    steps:
-      - name: Deploy to Staging
-        uses: appleboy/ssh-action@v1.2.0
-        with:
-          host: ${{ secrets.STAGING_SERVER_HOST }}
-          username: ${{ secrets.STAGING_SERVER_USER }}
-          key: ${{ secrets.STAGING_SERVER_SSH_KEY }}
-          script: |
-            cd ${{ secrets.DEPLOY_PATH }}
-            git pull origin dev
-            make pull TAG=dev
-            make stop
-            make start
-            make migrate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,6 @@ jobs:
       contents: read
       packages: write
 
-    outputs:
-      image_tag: ${{ steps.meta.outputs.version }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -120,24 +117,3 @@ jobs:
             ${{ env.IMAGE_PREFIX }}/auth:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    environment: production
-
-    steps:
-      - name: Deploy to Production
-        uses: appleboy/ssh-action@v1.2.0
-        with:
-          host: ${{ secrets.PROD_SERVER_HOST }}
-          username: ${{ secrets.PROD_SERVER_USER }}
-          key: ${{ secrets.PROD_SERVER_SSH_KEY }}
-          script: |
-            cd ${{ secrets.DEPLOY_PATH }}
-            git fetch --tags
-            git checkout ${{ github.ref_name }}
-            make pull TAG=${{ needs.build.outputs.image_tag }}
-            make stop
-            make start
-            make migrate


### PR DESCRIPTION
## Summary

Modify the CI workflows to remove server deployment steps. The workflows now strictly perform **build and push** of Docker images to the GitHub Container Registry (GHCR).
## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI/CD or infrastructure change

## Changes Made

- Removed `deploy` job from `.github/workflows/dev.yml`
- Removed `deploy` job from `.github/workflows/release.yml`

## Related Issues

Closes #48

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)