### PR TITLE
feat(ci): support multi-arch builds (ARM64) in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
         env:
           IMAGE_PREFIX: ${{ env.IMAGE_PREFIX }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -52,6 +55,7 @@ jobs:
         with:
           context: ./backend
           file: ./backend/Dockerfile.postgres
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.IMAGE_PREFIX }}/postgres:${{ steps.meta.outputs.version }}
@@ -64,6 +68,7 @@ jobs:
         with:
           context: ./backend
           file: ./backend/Dockerfile.server
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.IMAGE_PREFIX }}/server:${{ steps.meta.outputs.version }}
@@ -76,6 +81,7 @@ jobs:
         with:
           context: ./backend
           file: ./backend/Dockerfile.worker
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.IMAGE_PREFIX }}/worker:${{ steps.meta.outputs.version }}
@@ -88,6 +94,7 @@ jobs:
         with:
           context: ./frontend
           file: ./frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.IMAGE_PREFIX }}/frontend:${{ steps.meta.outputs.version }}
@@ -103,6 +110,7 @@ jobs:
           context: ./frontend
           file: ./frontend/Dockerfile
           target: builder
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.IMAGE_PREFIX }}/frontend:${{ steps.meta.outputs.version }}-builder
@@ -117,6 +125,7 @@ jobs:
         with:
           context: ./auth
           file: ./auth/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.IMAGE_PREFIX }}/auth:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Summary

Adds support for ARM64 architecture (`linux/arm64`) to the Docker image release workflow, enabling deployments on Apple Silicon, AWS Graviton, and Raspberry Pi.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI/CD or infrastructure change

## Changes Made

- Added `docker/setup-qemu-action@v3` to `.github/workflows/release.yml` (required for multi-arch emulation)
- Updated `docker/build-push-action` steps for all services (postgres, server, worker, frontend, auth) to include `platforms: linux/amd64,linux/arm64`

## Related Issues

Closes #53

## Testing

- [x] I have tested these changes locally (verified workflow syntax and local buildx capability)
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass (CI verified)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

N/A