### PR TITLE
fix(ci): optimize release workflow caching with local files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: |
+            /tmp/.buildx-cache-postgres
+            /tmp/.buildx-cache-server
+            /tmp/.buildx-cache-worker
+            /tmp/.buildx-cache-frontend
+            /tmp/.buildx-cache-frontend-builder
+            /tmp/.buildx-cache-auth
+          key: docker-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            docker-${{ runner.os }}-
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -60,8 +74,8 @@ jobs:
           tags: |
             ${{ env.IMAGE_PREFIX }}/postgres:${{ steps.meta.outputs.version }}
             ${{ env.IMAGE_PREFIX }}/postgres:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache-postgres
+          cache-to: type=local,dest=/tmp/.buildx-cache-postgres-new,mode=max
 
       - name: Build and push server
         uses: docker/build-push-action@v6
@@ -73,8 +87,8 @@ jobs:
           tags: |
             ${{ env.IMAGE_PREFIX }}/server:${{ steps.meta.outputs.version }}
             ${{ env.IMAGE_PREFIX }}/server:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache-server
+          cache-to: type=local,dest=/tmp/.buildx-cache-server-new,mode=max
 
       - name: Build and push worker
         uses: docker/build-push-action@v6
@@ -86,8 +100,8 @@ jobs:
           tags: |
             ${{ env.IMAGE_PREFIX }}/worker:${{ steps.meta.outputs.version }}
             ${{ env.IMAGE_PREFIX }}/worker:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache-worker
+          cache-to: type=local,dest=/tmp/.buildx-cache-worker-new,mode=max
 
       - name: Build and push frontend
         uses: docker/build-push-action@v6
@@ -101,8 +115,8 @@ jobs:
             ${{ env.IMAGE_PREFIX }}/frontend:latest
           build-args: |
             NEXT_PUBLIC_API_URL=/api
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache-frontend
+          cache-to: type=local,dest=/tmp/.buildx-cache-frontend-new,mode=max
 
       - name: Build and push frontend-builder
         uses: docker/build-push-action@v6
@@ -117,8 +131,8 @@ jobs:
             ${{ env.IMAGE_PREFIX }}/frontend:latest-builder
           build-args: |
             NEXT_PUBLIC_API_URL=/api
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache-frontend-builder
+          cache-to: type=local,dest=/tmp/.buildx-cache-frontend-builder-new,mode=max
 
       - name: Build and push auth
         uses: docker/build-push-action@v6
@@ -130,5 +144,20 @@ jobs:
           tags: |
             ${{ env.IMAGE_PREFIX }}/auth:${{ steps.meta.outputs.version }}
             ${{ env.IMAGE_PREFIX }}/auth:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache-auth
+          cache-to: type=local,dest=/tmp/.buildx-cache-auth-new,mode=max
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache-postgres
+          mv /tmp/.buildx-cache-postgres-new /tmp/.buildx-cache-postgres
+          rm -rf /tmp/.buildx-cache-server
+          mv /tmp/.buildx-cache-server-new /tmp/.buildx-cache-server
+          rm -rf /tmp/.buildx-cache-worker
+          mv /tmp/.buildx-cache-worker-new /tmp/.buildx-cache-worker
+          rm -rf /tmp/.buildx-cache-frontend
+          mv /tmp/.buildx-cache-frontend-new /tmp/.buildx-cache-frontend
+          rm -rf /tmp/.buildx-cache-frontend-builder
+          mv /tmp/.buildx-cache-frontend-builder-new /tmp/.buildx-cache-frontend-builder
+          rm -rf /tmp/.buildx-cache-auth
+          mv /tmp/.buildx-cache-auth-new /tmp/.buildx-cache-auth


### PR DESCRIPTION
## Summary

Optimizes the Docker build caching strategy in the release workflow to prevent excessive cache generation and improve reuse.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI/CD or infrastructure change

## Changes Made

- Replaced `type=gha` (internal GitHub Actions cache) with `actions/cache` + `type=local` for Docker Buildx.
- Added explicit cache keys: `docker-${{ runner.os }}-${{ github.sha }}`.
- configured separate cache directories for each service (`postgres`, `server`, `worker`, `frontend`, `frontend-builder`, `auth`) in `/tmp/.buildx-cache-*`.
- Added a cleanup step to rotate cache directories after successful builds.

## Related Issues

Closes #55

## Testing

- [x] I have tested these changes locally (workflow syntax check)
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

N/A

### Note on Caching Strategy
We use a "swap" strategy (`cache-to` writes to a `-new` directory) to prevent the cache from growing indefinitely. Docker Buildx appends new layers but doesn't automatically prune old ones. By writing to a fresh directory and replacing the old cache at the end, we ensure that only relevant layers are stored for the next run.
