### PR TITLE
ci(github_actions): restrict dev build to app directories

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - dev
+    paths:
+      - 'backend/**'
+      - 'auth/**'
+      - 'frontend/**'
 
 concurrency:
   group: dev-pipeline


### PR DESCRIPTION
## Summary

Restricts the `dev image build` workflow to only trigger when changes occur in `backend/**`, `auth/**`, or `frontend/**` directories. This prevents unnecessary image builds for documentation or configuration changes.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI/CD or infrastructure change

## Changes Made

- Added `paths` filter to `.github/workflows/dev.yml` to exclude builds for non-application file changes.

## Related Issues

Closes #64

## Testing

- [x] I have tested these changes locally (Verified YAML syntax)
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->