### PR TITLE
Fix S3 presigned URL signature mismatch in nginx proxy

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -10,10 +10,18 @@ services:
     image: nginx:alpine
     ports:
       - "443:443"
+    environment:
+      - AWS_PUBLIC_ENDPOINT=${AWS_PUBLIC_ENDPOINT:-http://localhost:9000}
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/nginx.conf.template:/etc/nginx/nginx.conf.template:ro
       - ./certs:/etc/nginx/certs:ro
       - frontend-static:/usr/share/nginx/html:ro
+    command: >
+      /bin/sh -c "
+        export S3_PUBLIC_HOST=$$(echo $$AWS_PUBLIC_ENDPOINT | sed -E 's|^https?://([^/:]+).*|\1|');
+        envsubst '$${S3_PUBLIC_HOST}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf &&
+        nginx -g 'daemon off;'
+      "
     depends_on:
       frontend-builder:
         condition: service_completed_successfully

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -81,7 +81,9 @@ http {
             proxy_pass http://rustfs:9000/;
             proxy_http_version 1.1;
 
-            proxy_set_header Host $host;
+            # Use the public host for S3 presigned URL signature verification
+            # This must match the host used when generating presigned URLs (AWS_PUBLIC_ENDPOINT)
+            proxy_set_header Host ${S3_PUBLIC_HOST};
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## Summary
- Fix S3 presigned URL signature verification failure by ensuring nginx forwards the correct `Host` header matching the `AWS_PUBLIC_ENDPOINT` used when generating presigned URLs
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
## Changes Made
- Renamed `nginx/nginx.conf` to `nginx/nginx.conf.template` to support variable substitution
- Added `envsubst` command in nginx container to dynamically set `S3_PUBLIC_HOST` from `AWS_PUBLIC_ENDPOINT`
- Updated `proxy_set_header Host` to use the extracted S3 public host instead of `$host`
## Related Issues
Closes #69
## Testing
- [x] Verified presigned URLs work correctly with the nginx proxy
- [x] Tested file upload/download through the S3 endpoint
## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes