### PR TITLE
Add database backup and restore make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,7 @@ frontend/next-env.d.ts
 # Migrations (processed temp files)
 .migrations_processed/
 
+# Backups
+.backup/
+
 *.log


### PR DESCRIPTION
## Summary
- Add `make db-dump` and `make db-restore` commands for PostgreSQL database backup and restore operations
## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
## Changes Made
- Added `db-dump` target: Creates timestamped database dumps in `backups/` directory using `pg_dump` with custom format (`-Fc`)
- Added `db-restore` target: Restores database from a dump file with `--clean --if-exists` flags for safe restoration
- Both commands run via ephemeral Docker containers connected to the `kiwi_internal` network
- Updated `.PHONY` to include new targets
## Related Issues
Closes #59
## Testing
- [x] Tested `make db-dump` creates valid backup file
- [x] Tested `make db-restore DUMP_FILE=./backups/...` restores successfully
- [x] Verified error handling for missing DUMP_FILE parameter
## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes