### PR TITLE
fix(infra): resolve nginx startup race condition by waiting for auth health

### DIFF
--- a/auth/src/index.ts
+++ b/auth/src/index.ts
@@ -1,16 +1,22 @@
-import { Context, Elysia } from 'elysia';
-import { cors } from '@elysiajs/cors';
-import { auth } from './auth';
+import { cors } from "@elysiajs/cors";
+import { Context, Elysia } from "elysia";
+import { auth } from "./auth";
 
 const betterAuthView = (context: Context) => {
-    const BETTER_AUTH_ACCEPT_METHODS = ['POST', 'GET'];
-    if (BETTER_AUTH_ACCEPT_METHODS.includes(context.request.method)) {
-        return auth.handler(context.request);
-    } else {
-        context.status('Forbidden', { error: 'Method not allowed' });
-    }
+  const BETTER_AUTH_ACCEPT_METHODS = ["POST", "GET"];
+  if (BETTER_AUTH_ACCEPT_METHODS.includes(context.request.method)) {
+    return auth.handler(context.request);
+  } else {
+    context.status("Forbidden", { error: "Method not allowed" });
+  }
 };
 
-const app = new Elysia().use(cors()).all('/auth/*', betterAuthView).listen(4321);
+const app = new Elysia()
+  .use(cors())
+  .get("/auth/health", () => ({ status: "ok" }))
+  .all("/auth/*", betterAuthView)
+  .listen(4321);
 
-console.log(`Auth server is running at ${app.server?.hostname}:${app.server?.port}`);
+console.log(
+  `Auth server is running at ${app.server?.hostname}:${app.server?.port}`
+);

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -26,9 +26,9 @@ services:
       frontend-builder:
         condition: service_completed_successfully
       server:
-        condition: service_started
+        condition: service_healthy
       auth:
-        condition: service_started
+        condition: service_healthy
 
   # Build container that copies static files to a volume
   frontend-builder:

--- a/compose.yml
+++ b/compose.yml
@@ -20,6 +20,12 @@ services:
       DATABASE_URL: ${DATABASE_URL}
       AUTH_SECRET: ${AUTH_SECRET}
       AUTH_URL: ${AUTH_URL}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:4321/auth/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
Resolves a race condition where Nginx would fail to start because it attempted to resolve the `auth` host before the service was healthy. This PR adds a healthcheck endpoint to the Auth service and configures Docker Compose to make Nginx wait for `auth` to be healthy.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI/CD or infrastructure change

## Changes Made

- Added `/auth/health` endpoint to `auth/src/index.ts`
- Added healthcheck configuration for `auth` service in `compose.yml`
- Updated `nginx` service in `compose.prod.yml` to wait for `auth` service to be `service_healthy`

## Related Issues

Closes #75

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [ ] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->