### PR TITLE
fix(backend): remove hardcoded bucket/module strings

### DIFF
--- a/backend/internal/queue/handler.go
+++ b/backend/internal/queue/handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/OFFIS-RIT/kiwi/backend/internal/db"
 	"github.com/OFFIS-RIT/kiwi/backend/internal/storage"
+	"github.com/OFFIS-RIT/kiwi/backend/internal/util"
 	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
 	graphstorage "github.com/OFFIS-RIT/kiwi/backend/pkg/store/base"
 
@@ -79,7 +80,8 @@ func ProcessGraphMessage(
 		projectState = "update"
 	}
 
-	s3L := s3.NewS3GraphFileLoaderWithClient("github.com/OFFIS-RIT/kiwi", s3Client)
+	s3Bucket := util.GetEnvString("AWS_BUCKET", "kiwi")
+	s3L := s3.NewS3GraphFileLoaderWithClient(s3Bucket, s3Client)
 	files := make([]loader.GraphFile, 0)
 
 	for _, file := range *data.ProjectFiles {
@@ -383,8 +385,9 @@ func ProcessPreprocess(
 	files := make([]loader.GraphFile, 0)
 	noProcessingFiles := make([]loader.GraphFile, 0)
 	pageCount := 0
+	s3Bucket := util.GetEnvString("AWS_BUCKET", "kiwi")
 	for _, upload := range *data.ProjectFiles {
-		s3L := s3.NewS3GraphFileLoaderWithClient("github.com/OFFIS-RIT/kiwi", s3Client)
+		s3L := s3.NewS3GraphFileLoaderWithClient(s3Bucket, s3Client)
 		ocrL := ocr.NewOCRGraphLoader(ocr.NewOCRGraphLoaderParams{
 			AIClient: aiClient,
 		})
@@ -493,7 +496,7 @@ func ProcessPreprocess(
 			files = append(files, f)
 
 			head, err := s3Client.HeadObject(ctx, &awss3.HeadObjectInput{
-				Bucket: aws.String("github.com/OFFIS-RIT/kiwi"),
+				Bucket: aws.String(util.GetEnv("AWS_BUCKET")),
 				Key:    aws.String(upload.FileKey),
 			})
 			if err == nil && head.ContentLength != nil {
@@ -517,7 +520,7 @@ func ProcessPreprocess(
 			files = append(files, f)
 
 			head, err := s3Client.HeadObject(ctx, &awss3.HeadObjectInput{
-				Bucket: aws.String("github.com/OFFIS-RIT/kiwi"),
+				Bucket: aws.String(util.GetEnv("AWS_BUCKET")),
 				Key:    aws.String(upload.FileKey),
 			})
 			if err == nil && head.ContentLength != nil {

--- a/backend/pkg/loader/util.go
+++ b/backend/pkg/loader/util.go
@@ -21,7 +21,7 @@ func TransformDocToPdf(input []byte, ext string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("nanoid: %w", err)
 	}
-	tmpDir := filepath.Join(os.TempDir(), "github.com/OFFIS-RIT/kiwi-ocr-"+id)
+	tmpDir := filepath.Join(os.TempDir(), "kiwi-ocr-"+id)
 	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir tmp: %w", err)
 	}
@@ -73,7 +73,7 @@ func TransformDocToImages(input []byte, ext string) ([][]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("nanoid: %w", err)
 	}
-	tmpDir := filepath.Join(os.TempDir(), "github.com/OFFIS-RIT/kiwi-ocr-"+id)
+	tmpDir := filepath.Join(os.TempDir(), "kiwi-ocr-"+id)
 	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir tmp: %w", err)
 	}
@@ -125,7 +125,7 @@ func TransformPdfToImages(input []byte) ([][]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("nanoid: %w", err)
 	}
-	tmpDir := filepath.Join(os.TempDir(), "github.com/OFFIS-RIT/kiwi-ocr-"+id)
+	tmpDir := filepath.Join(os.TempDir(), "kiwi-ocr-"+id)
 	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir tmp: %w", err)
 	}
@@ -195,7 +195,7 @@ func CountPDFPages(input []byte) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("nanoid: %w", err)
 	}
-	tmpDir := filepath.Join(os.TempDir(), "github.com/OFFIS-RIT/kiwi-count-"+id)
+	tmpDir := filepath.Join(os.TempDir(), "kiwi-count-"+id)
 	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
 		return 0, fmt.Errorf("mkdir tmp: %w", err)
 	}
@@ -259,7 +259,7 @@ func TransformExcelToCsv(input []byte, ext string) (map[string][]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("nanoid: %w", err)
 	}
-	tmpDir := filepath.Join(os.TempDir(), "github.com/OFFIS-RIT/kiwi-excel-"+id)
+	tmpDir := filepath.Join(os.TempDir(), "kiwi-excel-"+id)
 	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir tmp: %w", err)
 	}


### PR DESCRIPTION
## Summary

Replace hardcoded S3 bucket references with AWS_BUCKET and normalize temp dir prefixes to remove accidental module-path strings.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Replace hardcoded S3 bucket usage with AWS_BUCKET in preprocess sizing logic
- Normalize temp directory prefixes in loader utilities

## Related Issues

Closes #76

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->