### PR TITLE
refactore: Replace MinIO mc with AWS CLI for RustFS setup

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -180,24 +180,27 @@ services:
       start_period: 40s
   rustfs-setup:
     container_name: rustfs-setup
-    image: minio/mc:latest
+    image: amazon/aws-cli:latest
     depends_on:
-      rustfs:
-        condition: service_healthy
+        rustfs:
+            condition: service_healthy
     environment:
-      AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
-      AWS_SECRET_KEY: ${AWS_SECRET_KEY}
-      AWS_ENDPOINT: ${AWS_ENDPOINT}
-      AWS_BUCKET: ${AWS_BUCKET}
+        AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY}
+        AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_KEY}
+        AWS_DEFAULT_REGION: us-east-1
+        AWS_ENDPOINT: ${AWS_ENDPOINT}
+        AWS_BUCKET: ${AWS_BUCKET}
     entrypoint: >
-      /bin/sh -c " set -e; mc alias set myrustfs ${AWS_ENDPOINT} ${AWS_ACCESS_KEY}
-      ${AWS_SECRET_KEY}; if mc ls myrustfs/${AWS_BUCKET} > /dev/null 2>&1; then
-        echo 'Bucket already exists, skipping init...';
-      else
-        echo 'Setting up bucket';
-        mc mb myrustfs/${AWS_BUCKET};
-        echo 'Setup completed';
-      fi "
+        sh -c "
+        set -e;
+        if aws --endpoint-url ${AWS_ENDPOINT} s3 ls s3://${AWS_BUCKET} >/dev/null 2>&1; then
+            echo 'Bucket already exists, skipping init...';
+        else
+            echo 'Setting up bucket';
+            aws --endpoint-url ${AWS_ENDPOINT} s3 mb s3://${AWS_BUCKET};
+            echo 'Setup completed';
+        fi
+        "
   ollama:
     container_name: ollama
     image: ollama/ollama


### PR DESCRIPTION
## Summary
Switch the RustFS setup container from `minio/mc` to `amazon/aws-cli` to avoid `minio/mc` license constraints.
## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI/CD or infrastructure change
## Changes Made
- Update `rustfs-setup` image to `amazon/aws-cli`
- Replace `mc` bucket setup with `aws s3` commands
## Related Issues
Closes #81
## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass
## Checklist
- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [x] I have run `make generate` if SQL queries were modified (backend)
- [x] I have updated barrel exports if components were added (frontend)
## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->