### PR TITLE
fix(backend): correct PNG data URI for image processing

### DIFF
--- a/backend/pkg/ai/openai/image.go
+++ b/backend/pkg/ai/openai/image.go
@@ -20,13 +20,14 @@ func (c *GraphOpenAIClient) GenerateImageDescription(
 ) (string, error) {
 	client := c.ImageClient
 
+	url := fmt.Sprintf("%s%s", base64.FileType, base64.Base64)
 	body := openai.ChatCompletionNewParams{
 		Model: openai.ChatModel(c.imageModel),
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			openai.SystemMessage(prompt),
 			openai.UserMessage([]openai.ChatCompletionContentPartUnionParam{
 				openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
-					URL: fmt.Sprintf("%s%s", base64.FileType, base64.Base64),
+					URL: url,
 				}),
 			}),
 		},

--- a/backend/pkg/loader/image/image.go
+++ b/backend/pkg/loader/image/image.go
@@ -55,7 +55,7 @@ func GetFileTextFromIO(ctx context.Context, aiClient ai.GraphAIClient, input io.
 	}
 
 	b64String := base64.StdEncoding.EncodeToString(content)
-	filePrefix := "data:application/png;base64,"
+	filePrefix := "data:image/png;base64,"
 	b64Image := loader.GraphBase64{
 		Base64:   b64String,
 		FileType: filePrefix,

--- a/backend/pkg/loader/ocr/ocr.go
+++ b/backend/pkg/loader/ocr/ocr.go
@@ -54,7 +54,7 @@ func (l *OCRGraphLoader) ProcessImages(ctx context.Context, file loader.GraphFil
 			logger.Debug("[OCR] Processing image", "number", idx+1, "total", len(images))
 			prompt := ai.TranscribePrompt
 			b64String := base64.StdEncoding.EncodeToString(image)
-			filePrefix := "data:application/png;base64,"
+			filePrefix := "data:image/png;base64,"
 			b64 := loader.GraphBase64{
 				Base64:   b64String,
 				FileType: filePrefix,


### PR DESCRIPTION
## Summary
Fix PNG data URI prefixes in image/OCR loaders so OpenAI image inputs use the correct MIME type.
## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change
## Changes Made
- Fix PNG data URI prefix to `image/png` in image and OCR loaders
- Reuse the assembled image URL in OpenAI image completion payload
## Related Issues
Closes #90 
## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass
## Checklist
- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [x] I have run `make generate` if SQL queries were modified (backend)
- [x] I have updated barrel exports if components were added (frontend)
## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->