### PR TITLE
fix(backend): implement per-row table chunking with token limit enforcement

### DIFF
--- a/backend/pkg/loader/util_test.go
+++ b/backend/pkg/loader/util_test.go
@@ -9,8 +9,8 @@ func TestNormalizeMarkdownImageDescriptions(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "duplicate description with normalized whitespace",
-			input: "Intro\n![Garden with a winding stone path and central fountain.](image.jpg)\n\nGarden with a winding stone path\nand central fountain.\n\nNext.",
+			name:     "duplicate description with normalized whitespace",
+			input:    "Intro\n![Garden with a winding stone path and central fountain.](image.jpg)\n\nGarden with a winding stone path\nand central fountain.\n\nNext.",
 			expected: "Intro\n\n<image>Garden with a winding stone path\nand central fountain.</image>\n\nNext.",
 		},
 		{
@@ -19,18 +19,18 @@ func TestNormalizeMarkdownImageDescriptions(t *testing.T) {
 			expected: "Intro\n<image>Simple diagram of layout</image>\nNext.",
 		},
 		{
-			name: "multiple image tags",
-			input: "![First image description with detail.](a.png)\nFirst image description with detail.\n\n![Second image description with detail](b.png)\nMore text.",
+			name:     "multiple image tags",
+			input:    "![First image description with detail.](a.png)\nFirst image description with detail.\n\n![Second image description with detail](b.png)\nMore text.",
 			expected: "\n<image>First image description with detail.</image>\n\n<image>Second image description with detail</image>\nMore text.",
 		},
 		{
-			name: "duplicate description after intervening text",
-			input: "Intro\n![Quiet harbor with fishing boats near cliffs.](image.jpg)\nAdditional notes appear here.\nSome other line.\n\nQuiet harbor with fishing boats near cliffs.\nMore text.",
+			name:     "duplicate description after intervening text",
+			input:    "Intro\n![Quiet harbor with fishing boats near cliffs.](image.jpg)\nAdditional notes appear here.\nSome other line.\n\nQuiet harbor with fishing boats near cliffs.\nMore text.",
 			expected: "Intro\nAdditional notes appear here.\nSome other line.\n\n<image>Quiet harbor with fishing boats near cliffs.</image>\nMore text.",
 		},
 		{
-			name: "extra markdown text without duplicate",
-			input: "Start\n![Night skyline with neon signs and crowded streets.](scene.png)\nDifferent sentence follows with no exact match.\nEnd.",
+			name:     "extra markdown text without duplicate",
+			input:    "Start\n![Night skyline with neon signs and crowded streets.](scene.png)\nDifferent sentence follows with no exact match.\nEnd.",
 			expected: "Start\n<image>Night skyline with neon signs and crowded streets.</image>\nDifferent sentence follows with no exact match.\nEnd.",
 		},
 	}


### PR DESCRIPTION
## Summary
Implements intelligent table chunking that respects token limits by treating table rows as individual segments instead of processing entire tables as single sentences. This prevents excessive context window growth when processing documents with large tables.
## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change
## Changes Made
- Introduced `unitSegment` type with `segmentText` and `segmentTableRow` kinds to distinguish between regular text and table rows
- Implemented `splitIntoSegments()` function to parse markdown tables and detect table boundaries using delimiter pattern recognition
- Created `buildChunkText()` helper that constructs chunks with proper table header repetition for each chunk containing table rows
- Modified `transformIntoUnits()` to use segment-based chunking instead of sentence-based chunking
- Added comprehensive test coverage for table chunking scenarios with token limit validation
- Table rows are now chunked individually while preserving the header in each chunk for context continuity
## Related Issues
Closes #99
## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass
**Test Coverage:**
- `TestTransformIntoUnitsMarkdownTableChunking` validates table row splitting with header repetition
- `TestTransformIntoUnitsMarkdownTableChunking` verifies chunking behavior with surrounding text
- Tests confirm token limits are enforced per-row instead of per-table
## Checklist
- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [x] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)
## Screenshots (if applicable)
N/A - Backend logic changes only