### PR TITLE
feat(frontend): right-align file size in file selection list

### DIFF
--- a/frontend/components/projects/FileUploader.tsx
+++ b/frontend/components/projects/FileUploader.tsx
@@ -94,25 +94,27 @@ export function FileUploader({ files, setFiles }: FileUploaderProps) {
             {files.map((file, index) => (
               <li
                 key={index}
-                className="flex items-center justify-between rounded-md bg-muted p-2 text-sm"
+                className="flex items-center justify-between gap-2 rounded-md bg-muted p-2 text-sm"
               >
-                <div className="flex items-center gap-2">
-                  <FileText className="h-4 w-4" />
-                  <span className="truncate max-w-[300px]">{file.name}</span>
-                  <span className="text-xs text-muted-foreground">
-                    ({formatFileSize(file.size)})
-                  </span>
+                <div className="flex items-center gap-2 min-w-0">
+                  <FileText className="h-4 w-4 flex-shrink-0" />
+                  <span className="truncate">{file.name}</span>
                 </div>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6"
-                  onClick={() => removeFile(index)}
-                >
-                  <X className="h-4 w-4" />
-                  <span className="sr-only">{t("remove.file")}</span>
-                </Button>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <span className="text-xs text-muted-foreground">
+                    {formatFileSize(file.size)}
+                  </span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6"
+                    onClick={() => removeFile(index)}
+                  >
+                    <X className="h-4 w-4" />
+                    <span className="sr-only">{t("remove.file")}</span>
+                  </Button>
+                </div>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary

Update the file selection list in the Create Project dialog to right-align file sizes immediately to the left of the delete button for better visual consistency and scanning.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Moved file size display from the left-aligned filename container to a new right-aligned container
- File size is now positioned immediately to the left of the delete (X) button
- Added proper flex utilities (`min-w-0`, `flex-shrink-0`) to ensure filename truncation works correctly
- Removed parentheses from file size for cleaner appearance

## Related Issues

Closes #102

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass

Ran `bun run build`, `bun run lint`, and `bun run format:check` successfully.

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

<img width="569" height="143" alt="image" src="https://github.com/user-attachments/assets/aaf5219c-208a-46a3-87c4-a4decc0fc878" />