### PR TITLE
refactor(backend): remove unused SSE endpoint

### DIFF
--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -34,9 +34,6 @@ func RegisterRoutes(e *echo.Echo) {
 	apiRoutes.POST("/projects/:id/query", routes.QueryProjectHandler)
 	apiRoutes.POST("/projects/:id/stream", routes.QueryProjectStreamHandler)
 
-	// Project event routes
-	apiRoutes.GET("/projects/:id/events", routes.GetProjectEventsHandler)
-
 	// Group Routes
 	apiRoutes.GET("/groups", routes.GetGroupsHandler, middleware.RequireAnyPermission("group.view", "group.view:all"))
 	apiRoutes.POST("/groups", routes.CreateGroupHandler, middleware.RequirePermission("group.create"))


### PR DESCRIPTION
## Summary
Removes the redundant Server-Sent Events (SSE) endpoint `GET /projects/:id/events` and its associated handler from the backend. This endpoint is no longer consumed by the frontend and represents dead code that increases API surface area unnecessarily.
## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change
## Changes Made
- Removed `GetProjectEventsHandler` function from `backend/internal/server/routes/get_projects.go`
- Removed route registration `apiRoutes.GET("/projects/:id/events", ...)` from `backend/internal/server/routes.go`
- Cleaned up unused import `github.com/OFFIS-RIT/kiwi/backend/internal/util` from get_projects.go
## Related Issues
Closes #113
## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass
## Checklist
- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)
## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->