### PR TITLE
feat(frontend): display active project processing count on group cards

### DIFF
--- a/frontend/components/groups/GroupCard.tsx
+++ b/frontend/components/groups/GroupCard.tsx
@@ -3,7 +3,7 @@
 import { CardTemplate } from "@/components/common/CardTemplate";
 import { useLanguage } from "@/providers/LanguageProvider";
 import type { Group } from "@/types";
-import { FileText, Users } from "lucide-react";
+import { FileText, Loader2, Users } from "lucide-react";
 
 type GroupCardProps = {
   group: Group;
@@ -13,6 +13,9 @@ type GroupCardProps = {
 
 export function GroupCard({ group, onSelect, onEdit }: GroupCardProps) {
   const { t } = useLanguage();
+  const processingCount = group.projects.filter(
+    (p) => p.processPercentage !== undefined
+  ).length;
 
   return (
     <CardTemplate
@@ -29,6 +32,14 @@ export function GroupCard({ group, onSelect, onEdit }: GroupCardProps) {
           {group.projects.length} {t("knowledge.projects")}
         </span>
       </div>
+      {processingCount > 0 && (
+        <div className="mt-2 flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span>
+            {t("projects.processing", { count: processingCount.toString() })}
+          </span>
+        </div>
+      )}
     </CardTemplate>
   );
 }

--- a/frontend/providers/LanguageProvider.tsx
+++ b/frontend/providers/LanguageProvider.tsx
@@ -131,6 +131,7 @@ const translations = {
     "process.failed": "Failed",
     "process.remaining": "~{time} remaining",
     processing: "Processing...",
+    "projects.processing": "{count} processing",
 
     // Language
     language: "Language",
@@ -306,6 +307,7 @@ const translations = {
     "process.failed": "Fehlgeschlagen",
     "process.remaining": "~{time} verbleibend",
     processing: "Verarbeitung...",
+    "projects.processing": "{count} in Verarbeitung",
 
     // Language
     language: "Sprache",


### PR DESCRIPTION
## Summary

This PR implements a feature to display the active project processing count on Group Overview cards. Users can now see at a glance how many projects within a group are currently processing (e.g., ingesting files, creating graphs), improving observability without needing to navigate into individual groups.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Update `GroupCard.tsx` to calculate and display the number of active processing projects.
- Add a spinner icon (`Loader2`) and count text (e.g., "2 processing") to the group card.
- Add translation keys for English and German in `LanguageProvider.tsx`.

## Related Issues

Closes #105

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [x] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

<img width="462" height="269" alt="image" src="https://github.com/user-attachments/assets/13844370-9d43-4b7f-ac3a-b7669bd99a33" />