### PR TITLE
fix(backend): resolve batch status enum type mismatch causing stale progress reporting

### DIFF
--- a/backend/internal/db/batch.sql.go
+++ b/backend/internal/db/batch.sql.go
@@ -445,9 +445,9 @@ func (q *Queries) UpdateBatchEstimatedDuration(ctx context.Context, arg UpdateBa
 
 const updateBatchStatus = `-- name: UpdateBatchStatus :exec
 UPDATE project_batch_status
-SET status = $3,
-    started_at = CASE WHEN $3 IN ('preprocessing', 'extracting', 'indexing') THEN NOW() ELSE started_at END,
-    completed_at = CASE WHEN $3 IN ('completed', 'failed') THEN NOW() ELSE completed_at END,
+SET status = $3::text,
+    started_at = CASE WHEN $3::text IN ('preprocessing', 'extracting', 'indexing') THEN NOW() ELSE started_at END,
+    completed_at = CASE WHEN $3::text IN ('completed', 'failed') THEN NOW() ELSE completed_at END,
     error_message = $4
 WHERE correlation_id = $1 AND batch_id = $2
 `
@@ -455,7 +455,7 @@ WHERE correlation_id = $1 AND batch_id = $2
 type UpdateBatchStatusParams struct {
 	CorrelationID string      `json:"correlation_id"`
 	BatchID       int32       `json:"batch_id"`
-	Status        string      `json:"status"`
+	Column3       string      `json:"column_3"`
 	ErrorMessage  pgtype.Text `json:"error_message"`
 }
 
@@ -463,7 +463,7 @@ func (q *Queries) UpdateBatchStatus(ctx context.Context, arg UpdateBatchStatusPa
 	_, err := q.db.Exec(ctx, updateBatchStatus,
 		arg.CorrelationID,
 		arg.BatchID,
-		arg.Status,
+		arg.Column3,
 		arg.ErrorMessage,
 	)
 	return err

--- a/backend/internal/db/queries/batch.sql
+++ b/backend/internal/db/queries/batch.sql
@@ -6,9 +6,9 @@ RETURNING *;
 
 -- name: UpdateBatchStatus :exec
 UPDATE project_batch_status
-SET status = $3,
-    started_at = CASE WHEN $3 IN ('preprocessing', 'extracting', 'indexing') THEN NOW() ELSE started_at END,
-    completed_at = CASE WHEN $3 IN ('completed', 'failed') THEN NOW() ELSE completed_at END,
+SET status = $3::text,
+    started_at = CASE WHEN $3::text IN ('preprocessing', 'extracting', 'indexing') THEN NOW() ELSE started_at END,
+    completed_at = CASE WHEN $3::text IN ('completed', 'failed') THEN NOW() ELSE completed_at END,
     error_message = $4
 WHERE correlation_id = $1 AND batch_id = $2;
 

--- a/backend/internal/queue/handler.go
+++ b/backend/internal/queue/handler.go
@@ -75,7 +75,7 @@ func ProcessGraphMessage(
 		_ = q.UpdateBatchStatus(ctx, db.UpdateBatchStatusParams{
 			CorrelationID: data.CorrelationID,
 			BatchID:       int32(data.BatchID),
-			Status:        "extracting",
+			Column3:        "extracting",
 		})
 	}
 
@@ -283,7 +283,7 @@ func ProcessGraphMessage(
 			_ = q.UpdateBatchStatus(ctx, db.UpdateBatchStatusParams{
 				CorrelationID: data.CorrelationID,
 				BatchID:       int32(data.BatchID),
-				Status:        "failed",
+				Column3:        "failed",
 				ErrorMessage:  pgtype.Text{String: err.Error(), Valid: true},
 			})
 		}
@@ -312,7 +312,7 @@ func ProcessGraphMessage(
 		_ = q.UpdateBatchStatus(ctx, db.UpdateBatchStatusParams{
 			CorrelationID: data.CorrelationID,
 			BatchID:       int32(data.BatchID),
-			Status:        "indexing",
+			Column3:        "indexing",
 		})
 	}
 
@@ -337,7 +337,7 @@ func ProcessGraphMessage(
 			_ = q.UpdateBatchStatus(ctx, db.UpdateBatchStatusParams{
 				CorrelationID: data.CorrelationID,
 				BatchID:       int32(data.BatchID),
-				Status:        "failed",
+				Column3:        "failed",
 				ErrorMessage:  pgtype.Text{String: err.Error(), Valid: true},
 			})
 		}
@@ -363,7 +363,7 @@ func ProcessGraphMessage(
 		_ = q.UpdateBatchStatus(ctx, db.UpdateBatchStatusParams{
 			CorrelationID: data.CorrelationID,
 			BatchID:       int32(data.BatchID),
-			Status:        "completed",
+			Column3:        "completed",
 		})
 
 		allDone, checkErr := q.AreAllBatchesCompleted(ctx, data.CorrelationID)
@@ -484,7 +484,7 @@ func ProcessPreprocess(
 		_ = q.UpdateBatchStatus(ctx, db.UpdateBatchStatusParams{
 			CorrelationID: data.CorrelationID,
 			BatchID:       int32(data.BatchID),
-			Status:        "preprocessing",
+			Column3:        "preprocessing",
 		})
 	}
 
@@ -898,7 +898,7 @@ func ProcessPreprocess(
 		_ = q.UpdateBatchStatus(ctx, db.UpdateBatchStatusParams{
 			CorrelationID: data.CorrelationID,
 			BatchID:       int32(data.BatchID),
-			Status:        "preprocessed",
+			Column3:        "preprocessed",
 		})
 	}
 

--- a/backend/internal/server/routes/post_projects.go
+++ b/backend/internal/server/routes/post_projects.go
@@ -205,6 +205,7 @@ func CreateProjectHandler(c echo.Context) error {
 			fileIDs[i] = f.ID
 		}
 
+		logger.Debug("[Server] Creating batch status", "project_id", project.ID, "correlation_id", correlationID, "batch_id", batchID, "total_batches", totalBatches, "files_count", len(batchFiles))
 		_, _ = q.CreateBatchStatus(ctx, db.CreateBatchStatusParams{
 			ProjectID:     project.ID,
 			CorrelationID: correlationID,

--- a/compose.yml
+++ b/compose.yml
@@ -74,6 +74,8 @@ services:
       MASTER_API_KEY: ${MASTER_API_KEY}
       MASTER_USER_ID: ${MASTER_USER_ID}
       MASTER_USER_ROLE: ${MASTER_USER_ROLE}
+      WORKER_PREFETCH: ${WORKER_PREFETCH}
+      WORKER_BATCH_SIZE: ${WORKER_BATCH_SIZE}
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:8080/health || exit 1"]
       interval: 30s
@@ -124,6 +126,8 @@ services:
       RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD}
       RABBITMQ_HOST: ${RABBITMQ_HOST}
       RABBITMQ_PORT: ${RABBITMQ_PORT}
+      WORKER_PREFETCH: ${WORKER_PREFETCH}
+      WORKER_BATCH_SIZE: ${WORKER_BATCH_SIZE}
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Fixed PostgreSQL enum type casting issue in batch status updates
- Resolved stale progress reporting during file processing stages
- Added debug logging for batch status creation
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
## Changes Made
- Updated SQL query to explicitly cast $3 parameter to text type for enum comparison
- Fixed generated sqlc code where Status field was renamed to Column3 due to type mismatch
- Updated all queue handler calls to use correct field name
- Added debug logging for batch status creation in project creation endpoint
## Related Issues
Fixes #121 - Projects endpoint reporting 0% progress during processing phase
## Testing
- Verified batch status updates correctly propagate through preprocessing and graph extraction stages
- Confirmed progress percentage now updates accurately during file processing
- Tested queue transitions between preprocess_queue and graph_queue
## Checklist
- [x] Code follows project style guidelines
- [x] Self-review of changes completed
- [x] Testing performed manually
- [x] Documentation updated if needed