### PR TITLE
fix(frontend): consistent card height and footer alignment

### DIFF
--- a/frontend/components/common/CardTemplate.tsx
+++ b/frontend/components/common/CardTemplate.tsx
@@ -42,13 +42,15 @@ export function CardTemplate({
   const { t } = useLanguage();
 
   return (
-    <Card className="overflow-hidden transition-all hover:shadow-md">
-      <CardHeader className="pb-3">
+    <Card className="flex h-full min-h-[255px] flex-col gap-0 overflow-hidden pb-0 transition-all hover:shadow-md">
+      <CardHeader className="px-6 pb-4 min-h-[76px]">
         <CardTitle className="text-lg font-semibold">{title}</CardTitle>
         {description && <CardDescription>{description}</CardDescription>}
       </CardHeader>
-      <CardContent>{children}</CardContent>
-      <CardFooter className="flex items-center justify-between border-t bg-muted/50 px-6 py-3">
+      <CardContent className="flex-1 px-6 pb-6 min-h-[80px]">
+        {children}
+      </CardContent>
+      <CardFooter className="flex items-center justify-between border-t bg-muted/50 px-6 py-3 !pt-3">
         <Badge variant="outline" className="bg-background">
           <BadgeIcon className="mr-1 h-3 w-3" />
           {badgeText}

--- a/frontend/components/groups/GroupList.tsx
+++ b/frontend/components/groups/GroupList.tsx
@@ -37,7 +37,7 @@ export function GroupList({ onEditGroup }: GroupListProps) {
         <p className="text-muted-foreground">{t("select.group")}</p>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      <div className="grid auto-rows-fr items-stretch gap-4 md:grid-cols-2 lg:grid-cols-3">
         {groups.map((group) => (
           <GroupCard
             key={group.id}

--- a/frontend/components/projects/ProjectList.tsx
+++ b/frontend/components/projects/ProjectList.tsx
@@ -107,7 +107,7 @@ export function ProjectList({ onEditProject }: ProjectListProps) {
         <p className="text-muted-foreground">{t("select.knowledge.project")}</p>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      <div className="grid auto-rows-fr items-stretch gap-4 md:grid-cols-2 lg:grid-cols-3">
         {group.projects.map((project) => (
           <ProjectCard
             key={project.id}


### PR DESCRIPTION
## Summary

Fixes misalignment of bottom content in Group and Project cards, and ensures consistent card heights across all states (normal, processing, with/without description).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- **CardTemplate.tsx**: Added flex layout with `h-full`, `min-h-[250px]`, and `flex-col` to ensure consistent card height
- **CardTemplate.tsx**: Added `min-h-[76px]` to CardHeader for consistent header height with/without description
- **CardTemplate.tsx**: Added `flex-1` and `min-h-[80px]` to CardContent to push footer to bottom
- **CardTemplate.tsx**: Added `!pt-3` to CardFooter for symmetric vertical padding
- **GroupList.tsx**: Added `auto-rows-fr items-stretch` to grid for equal row heights
- **ProjectList.tsx**: Added `auto-rows-fr items-stretch` to grid for equal row heights

## Related Issues

Closes #128

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

N/A - Visual alignment fix