### PR TITLE
feat(frontend): Display project progress based on majority step

### DIFF
--- a/frontend/components/projects/ProjectCard.tsx
+++ b/frontend/components/projects/ProjectCard.tsx
@@ -79,9 +79,9 @@ export function ProjectCard({
                   <div className="text-xs space-y-1">
                     {project.processProgress &&
                       Object.entries(project.processProgress)
-                        .filter(([_, value]) => value) // Only show active steps
+                        .filter(([key, value]) => value && key !== "completed") // Hide completed
                         .map(([key, value]) => {
-                          const labelKey = `process.${key === "pending" ? "queued" : key === "preprocessing" ? "processing_files" : key === "extracting" ? "graph_creation" : key === "indexing" ? "saving" : key}`;
+                          const labelKey = `process.${key === "pending" ? "queued" : key === "preprocessing" || key === "preprocessed" ? "processing_files" : key === "extracting" ? "graph_creation" : key === "indexing" ? "saving" : key}`;
                           const translatedLabel = t(labelKey);
                           return (
                             <div


### PR DESCRIPTION
## Summary

Update the project progress display logic in Sidebar and Project Cards to show the processing step with the highest file count instead of the "furthest" step. This provides a more accurate representation of the overall project state.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Refactor `determineProcessStep` function in `use-data.ts` to use count-based majority logic
- Add `parseCount` helper function to safely parse string counts from API
- Aggregate related steps: `preprocessing` + `preprocessed` → `processing_files`
- Only display "queued" when ALL files are in queue (no active processing)
- Never display "completed" status; fallback to "saving" when all files are done
- Treat "failed" like any other step (only show if majority)
- Fix tooltip in `ProjectCard.tsx` to map `preprocessed` to user-friendly label
- Hide "completed" entries from tooltip display

## Related Issues

Closes #141

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [x] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

<!-- No UI layout changes, only logic changes to displayed text -->