### PR TITLE
feat(frontend): show completed status in project card tooltip

### DIFF
--- a/frontend/components/projects/ProjectCard.tsx
+++ b/frontend/components/projects/ProjectCard.tsx
@@ -79,7 +79,7 @@ export function ProjectCard({
                   <div className="text-xs space-y-1">
                     {project.processProgress &&
                       Object.entries(project.processProgress)
-                        .filter(([key, value]) => value && key !== "completed") // Hide completed
+                        .filter(([, value]) => value) // Show all non-empty values
                         .map(([key, value]) => {
                           const labelKey = `process.${key === "pending" ? "queued" : key === "preprocessing" || key === "preprocessed" ? "processing_files" : key === "extracting" ? "graph_creation" : key === "indexing" ? "saving" : key}`;
                           const translatedLabel = t(labelKey);


### PR DESCRIPTION
## Summary

Updated the `ProjectCard` processing tooltip to explicitly display the 'completed' status count instead of filtering it out. This provides users with a complete view of the processing progress, showing how many items have finished processing alongside those that are queued or in progress.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Modified `frontend/components/projects/ProjectCard.tsx` to include `completed` keys in the tooltip rendering logic.

## Related Issues

Closes #

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [ ] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->