### PR TITLE
feat(backend): add bulk upsert and batching for entities, relationships, and text units

### DIFF
--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -65,6 +65,7 @@ type Querier interface {
 	GetBatchesByCorrelation(ctx context.Context, correlationID string) ([]ProjectBatchStatus, error)
 	GetDeletedProjectFiles(ctx context.Context, projectID int64) ([]ProjectFile, error)
 	GetEntitiesWithSourcesFromUnits(ctx context.Context, arg GetEntitiesWithSourcesFromUnitsParams) ([]GetEntitiesWithSourcesFromUnitsRow, error)
+	GetEntityIDsByPublicIDs(ctx context.Context, arg GetEntityIDsByPublicIDsParams) ([]GetEntityIDsByPublicIDsRow, error)
 	GetEntityNeighbours(ctx context.Context, sourceID int64) ([]GetEntityNeighboursRow, error)
 	GetEntityNeighboursRanked(ctx context.Context, arg GetEntityNeighboursRankedParams) ([]GetEntityNeighboursRankedRow, error)
 	GetEntityTypes(ctx context.Context, projectID int64) ([]GetEntityTypesRow, error)
@@ -111,6 +112,7 @@ type Querier interface {
 	GetStagedUnits(ctx context.Context, arg GetStagedUnitsParams) ([][]byte, error)
 	GetStaleBatches(ctx context.Context) ([]ProjectBatchStatus, error)
 	GetTextUnitByPublicId(ctx context.Context, publicID string) (TextUnit, error)
+	GetTextUnitIDsByPublicIDs(ctx context.Context, publicIds []string) ([]GetTextUnitIDsByPublicIDsRow, error)
 	GetTextUnitIdsForFiles(ctx context.Context, dollar_1 []int64) ([]GetTextUnitIdsForFilesRow, error)
 	GetTokenCountOfFile(ctx context.Context, id int64) (int32, error)
 	GetUsers(ctx context.Context) ([]User, error)
@@ -145,6 +147,11 @@ type Querier interface {
 	UpdateRelationshipRank(ctx context.Context, arg UpdateRelationshipRankParams) error
 	UpdateRelationshipSourceEntity(ctx context.Context, arg UpdateRelationshipSourceEntityParams) error
 	UpdateRelationshipTargetEntity(ctx context.Context, arg UpdateRelationshipTargetEntityParams) error
+	UpsertEntitySources(ctx context.Context, arg UpsertEntitySourcesParams) error
+	UpsertProjectEntities(ctx context.Context, arg UpsertProjectEntitiesParams) ([]UpsertProjectEntitiesRow, error)
+	UpsertProjectRelationships(ctx context.Context, arg UpsertProjectRelationshipsParams) ([]UpsertProjectRelationshipsRow, error)
+	UpsertRelationshipSources(ctx context.Context, arg UpsertRelationshipSourcesParams) error
+	UpsertTextUnits(ctx context.Context, arg UpsertTextUnitsParams) ([]int64, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/backend/internal/db/queries/text_units.sql
+++ b/backend/internal/db/queries/text_units.sql
@@ -14,6 +14,28 @@ SELECT id, public_id FROM text_units WHERE project_file_id = ANY($1::bigint[]);
 SELECT * FROM text_units
 WHERE public_id = $1;
 
+-- name: GetTextUnitIDsByPublicIDs :many
+SELECT id, public_id
+FROM text_units
+WHERE public_id = ANY(sqlc.arg(public_ids)::text[]);
+
+-- name: UpsertTextUnits :many
+WITH input AS (
+    SELECT
+        u.public_id,
+        (sqlc.arg(project_file_ids)::bigint[])[u.ord]::bigint AS project_file_id,
+        (sqlc.arg(texts)::text[])[u.ord]::text AS text
+    FROM unnest(sqlc.arg(public_ids)::text[]) WITH ORDINALITY AS u(public_id, ord)
+)
+INSERT INTO text_units (public_id, project_file_id, text)
+SELECT public_id, project_file_id, text
+FROM input
+ON CONFLICT (public_id) DO UPDATE
+SET project_file_id = EXCLUDED.project_file_id,
+    text = EXCLUDED.text,
+    updated_at = NOW()
+RETURNING id;
+
 -- name: GetProjectIDFromTextUnit :one
 SELECT p.id FROM projects p
 JOIN project_files f ON f.project_id = p.id

--- a/backend/pkg/ai/ai.go
+++ b/backend/pkg/ai/ai.go
@@ -145,6 +145,8 @@ type GraphAIClient interface {
 	) (<-chan StreamEvent, error)
 
 	GenerateEmbedding(ctx context.Context, input []byte) ([]float32, error)
+	GenerateEmbeddings(ctx context.Context, inputs [][]byte) ([][]float32, error)
+	GenerateEmbeddingsChunks(ctx context.Context, chunks [][][]byte) ([][]float32, error)
 	GenerateImageDescription(
 		ctx context.Context,
 		prompt string,

--- a/backend/pkg/ai/openai/embedding.go
+++ b/backend/pkg/ai/openai/embedding.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -9,7 +10,7 @@ import (
 	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
 
 	"github.com/openai/openai-go/v3"
-	"github.com/openai/openai-go/v3/packages/param"
+	"golang.org/x/sync/errgroup"
 )
 
 const defaultDimensions = 4096
@@ -29,37 +30,121 @@ const defaultDimensions = 4096
 //	}
 //	fmt.Println("Embedding length:", len(embedding))
 func (c *GraphOpenAIClient) GenerateEmbedding(ctx context.Context, input []byte) ([]float32, error) {
+	res, err := c.GenerateEmbeddings(ctx, [][]byte{input})
+	if err != nil {
+		return nil, err
+	}
+	if len(res) != 1 {
+		return nil, fmt.Errorf("unexpected embedding result size: got %d want 1", len(res))
+	}
+	return res[0], nil
+}
+
+// GenerateEmbeddings creates embeddings for multiple inputs in a single request.
+// This is an internal fast path used by the storage layer.
+func (c *GraphOpenAIClient) GenerateEmbeddings(ctx context.Context, inputs [][]byte) ([][]float32, error) {
 	dim := int(util.GetEnvNumeric("AI_EMBED_DIM", defaultDimensions))
-	if len(input) == 0 || len(strings.TrimSpace(string(input))) == 0 {
-		return make([]float32, dim), nil
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+
+	idxMap, stringsIn, out := normalizeEmbeddingInputs(inputs, dim)
+	if len(stringsIn) == 0 {
+		return out, nil
+	}
+
+	stringsOut, err := c.generateEmbeddingsForStrings(ctx, stringsIn, dim)
+	if err != nil {
+		return nil, err
+	}
+	if len(stringsOut) != len(stringsIn) {
+		return nil, fmt.Errorf("embedding result size mismatch: got %d want %d", len(stringsOut), len(stringsIn))
+	}
+	for i := range stringsOut {
+		out[idxMap[i]] = stringsOut[i]
+	}
+	return out, nil
+}
+
+// GenerateEmbeddingsChunks generates embeddings for each chunk and returns a single
+// flattened result slice, preserving chunk order and input order within each chunk.
+//
+// Chunk requests are executed concurrently; the client's internal semaphore limits
+// actual parallelism.
+func (c *GraphOpenAIClient) GenerateEmbeddingsChunks(ctx context.Context, chunks [][][]byte) ([][]float32, error) {
+	if len(chunks) == 0 {
+		return nil, nil
+	}
+
+	outChunks := make([][][]float32, len(chunks))
+	eg, ectx := errgroup.WithContext(ctx)
+	for i := range chunks {
+		idx := i
+		chunk := chunks[i]
+		eg.Go(func() error {
+			res, err := c.GenerateEmbeddings(ectx, chunk)
+			if err != nil {
+				return err
+			}
+			outChunks[idx] = res
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	total := 0
+	for _, c := range outChunks {
+		total += len(c)
+	}
+	out := make([][]float32, 0, total)
+	for _, c := range outChunks {
+		out = append(out, c...)
+	}
+	return out, nil
+}
+
+func normalizeEmbeddingInputs(inputs [][]byte, dim int) (idxMap []int, stringsIn []string, out [][]float32) {
+	idxMap = make([]int, 0, len(inputs))
+	stringsIn = make([]string, 0, len(inputs))
+	out = make([][]float32, len(inputs))
+	for i, in := range inputs {
+		if len(in) == 0 || len(strings.TrimSpace(string(in))) == 0 {
+			out[i] = make([]float32, dim)
+			continue
+		}
+		idxMap = append(idxMap, i)
+		stringsIn = append(stringsIn, string(in))
+	}
+	return idxMap, stringsIn, out
+}
+
+func (c *GraphOpenAIClient) generateEmbeddingsForStrings(ctx context.Context, inputs []string, dim int) ([][]float32, error) {
+	if len(inputs) == 0 {
+		return nil, nil
 	}
 
 	rCtx, cancel := context.WithTimeout(ctx, time.Minute*time.Duration(c.timeoutMin))
 	defer cancel()
 
-	client := c.EmbeddingClient
-
 	body := openai.EmbeddingNewParams{
-		Input: openai.EmbeddingNewParamsInputUnion{
-			OfString: param.NewOpt(string(input)),
-		},
+		Input: openai.EmbeddingNewParamsInputUnion{OfArrayOfStrings: inputs},
 		Model: c.embeddingModel,
 	}
 
-	err := c.embeddingLock.Acquire(rCtx, 1)
-	if err != nil {
+	if err := c.embeddingLock.Acquire(rCtx, 1); err != nil {
 		return nil, err
 	}
 	defer c.embeddingLock.Release(1)
 
 	start := time.Now()
-	response, err := client.Embeddings.New(rCtx, body)
+	response, err := c.EmbeddingClient.Embeddings.New(rCtx, body)
 	if err != nil {
 		return nil, err
 	}
 
 	duration := time.Since(start).Milliseconds()
-
 	metrics := ai.ModelMetrics{
 		InputTokens:  int(response.Usage.PromptTokens),
 		OutputTokens: 0,
@@ -68,15 +153,34 @@ func (c *GraphOpenAIClient) GenerateEmbedding(ctx context.Context, input []byte)
 	}
 	c.modifyMetrics(metrics)
 
-	result := make([]float32, 0, dim)
-	for _, embedding := range response.Data {
-		for _, embed := range embedding.Embedding {
-			if len(result) >= dim {
-				break
-			}
-			result = append(result, float32(embed))
-		}
+	if len(response.Data) != len(inputs) {
+		return nil, fmt.Errorf("embedding response size mismatch: got %d want %d", len(response.Data), len(inputs))
 	}
 
-	return result, nil
+	out := make([][]float32, len(inputs))
+	for _, embedding := range response.Data {
+		dataIdx := int(embedding.Index)
+		if dataIdx < 0 || dataIdx >= len(inputs) {
+			return nil, fmt.Errorf("embedding index out of range: %d", embedding.Index)
+		}
+		vec := make([]float32, 0, dim)
+		for _, v := range embedding.Embedding {
+			if len(vec) >= dim {
+				break
+			}
+			vec = append(vec, float32(v))
+		}
+		if len(vec) < dim {
+			padded := make([]float32, dim)
+			copy(padded, vec)
+			vec = padded
+		}
+		out[dataIdx] = vec
+	}
+	for i := range out {
+		if out[i] == nil {
+			return nil, fmt.Errorf("missing embedding for index %d", i)
+		}
+	}
+	return out, nil
 }

--- a/backend/pkg/store/base/bulk.go
+++ b/backend/pkg/store/base/bulk.go
@@ -1,0 +1,36 @@
+package base
+
+func chunkRange(total, chunkSize int, fn func(start, end int) error) error {
+	if total <= 0 {
+		return nil
+	}
+	if chunkSize <= 0 {
+		chunkSize = total
+	}
+	for start := 0; start < total; start += chunkSize {
+		end := min(start + chunkSize, total)
+		if err := fn(start, end); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func dedupeStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}

--- a/backend/pkg/store/base/embeddings.go
+++ b/backend/pkg/store/base/embeddings.go
@@ -1,0 +1,50 @@
+package base
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/ai"
+	"golang.org/x/sync/errgroup"
+)
+
+type embeddingBatcher interface {
+	GenerateEmbeddings(ctx context.Context, inputs [][]byte) ([][]float32, error)
+}
+
+func generateEmbeddings(
+	ctx context.Context,
+	client ai.GraphAIClient,
+	inputs [][]byte,
+) ([][]float32, error) {
+	if client == nil {
+		return nil, fmt.Errorf("ai client is nil")
+	}
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+	if b, ok := client.(embeddingBatcher); ok {
+		return b.GenerateEmbeddings(ctx, inputs)
+	}
+
+	out := make([][]float32, len(inputs))
+
+	eg, ectx := errgroup.WithContext(ctx)
+	for i := range inputs {
+		idx := i
+		in := inputs[i]
+		eg.Go(func() error {
+			emb, err := client.GenerateEmbedding(ectx, in)
+			if err != nil {
+				return err
+			}
+			out[idx] = emb
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}

--- a/backend/pkg/store/base/relationship.go
+++ b/backend/pkg/store/base/relationship.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 
 	"github.com/OFFIS-RIT/kiwi/backend/pkg/common"
+	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
 
 	"github.com/pgvector/pgvector-go"
-	"golang.org/x/sync/errgroup"
 )
 
 func (s *GraphDBStorage) AddRelationship(
@@ -39,7 +39,7 @@ func (s *GraphDBStorage) AddRelationship(
 	})
 	s.dbLock.Unlock()
 	if err != nil {
-		return -1, nil
+		return -1, err
 	}
 
 	return id, nil
@@ -231,98 +231,248 @@ func (s *GraphDBStorage) getPathBetweenEntities(
 
 // SaveRelationships persists a batch of relationships and their sources to the
 // database. It generates vector embeddings for semantic search and links each
-// relationship to its source and target entities. All operations are wrapped
-// in a single transaction.
+// relationship to its source and target entities.
 func (s *GraphDBStorage) SaveRelationships(ctx context.Context, relations []common.Relationship, graphId string) ([]int64, error) {
-	ids := make([]int64, 0, len(relations))
+	if len(relations) == 0 {
+		return nil, nil
+	}
 
-	trx, err := s.conn.Begin(ctx)
+	projectID, err := strconv.ParseInt(graphId, 10, 64)
 	if err != nil {
 		return nil, err
 	}
 
-	q := db.New(s.conn)
-	qtx := q.WithTx(trx)
+	relChunk := 250
+	sourceChunk := 500
 
-	for _, relation := range relations {
-		embedding, err := s.aiClient.GenerateEmbedding(ctx, []byte(relation.Description))
-		if err != nil {
-			return nil, err
-		}
-		embed := pgvector.NewVector(embedding)
+	ids := make([]int64, 0, len(relations))
 
-		gId, err := strconv.ParseInt(graphId, 10, 64)
-		if err != nil {
-			return nil, err
+	err = chunkRange(len(relations), relChunk, func(start, end int) error {
+		merged := mergeRelationshipsByPublicID(relations[start:end])
+		if len(merged) == 0 {
+			return nil
 		}
 
-		source, err := qtx.GetProjectEntityByPublicID(ctx, relation.Source.ID)
-		if err != nil {
-			return nil, err
-		}
-		target, err := qtx.GetProjectEntityByPublicID(ctx, relation.Target.ID)
-		if err != nil {
-			return nil, err
-		}
+		logger.Debug("[Graph][SaveRelationships] Saving chunk", "relationships", len(merged))
 
-		id, err := qtx.AddProjectRelationship(ctx, db.AddProjectRelationshipParams{
-			PublicID:    relation.ID,
-			ProjectID:   gId,
-			SourceID:    source.ID,
-			TargetID:    target.ID,
-			Description: relation.Description,
-			Rank:        relation.Strength,
-			Embedding:   embed,
+		tx, err := s.conn.Begin(ctx)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback(ctx)
+		qtx := db.New(tx)
+
+		entityPublicIDs := make([]string, 0, len(merged)*2)
+		for _, r := range merged {
+			if r.Source != nil {
+				entityPublicIDs = append(entityPublicIDs, r.Source.ID)
+			}
+			if r.Target != nil {
+				entityPublicIDs = append(entityPublicIDs, r.Target.ID)
+			}
+		}
+		entityRows, err := qtx.GetEntityIDsByPublicIDs(ctx, db.GetEntityIDsByPublicIDsParams{
+			ProjectID: projectID,
+			PublicIds: dedupeStrings(entityPublicIDs),
 		})
 		if err != nil {
-			return nil, err
+			return err
+		}
+		entityIDByPublicID := make(map[string]int64, len(entityRows))
+		for _, r := range entityRows {
+			entityIDByPublicID[r.PublicID] = r.ID
 		}
 
-		eg, gCtx := errgroup.WithContext(ctx)
-		for _, src := range relation.Sources {
-			sSrc := src
+		relInputs := make([][]byte, len(merged))
+		for i := range merged {
+			relInputs[i] = []byte(merged[i].Description)
+		}
+		logger.Debug("[Graph][SaveRelationships] Generating relationship embeddings", "count", len(relInputs))
+		relEmb, err := generateEmbeddings(ctx, s.aiClient, relInputs)
+		if err != nil {
+			return err
+		}
 
-			eg.Go(func() error {
-				srcEmbedding, err := s.aiClient.GenerateEmbedding(gCtx, []byte(sSrc.Description))
+		relPublicIDs := make([]string, 0, len(merged))
+		sourceIDs := make([]int64, 0, len(merged))
+		targetIDs := make([]int64, 0, len(merged))
+		ranks := make([]float64, 0, len(merged))
+		descriptions := make([]string, 0, len(merged))
+		embeddings := make([]pgvector.Vector, 0, len(merged))
+		for i, r := range merged {
+			if r.ID == "" {
+				return fmt.Errorf("relationship public_id is empty")
+			}
+			if r.Source == nil || r.Target == nil {
+				return fmt.Errorf("relationship missing source/target: public_id=%s", r.ID)
+			}
+			sID, ok := entityIDByPublicID[r.Source.ID]
+			if !ok {
+				return fmt.Errorf("missing source entity: relationship=%s entity_public_id=%s", r.ID, r.Source.ID)
+			}
+			tID, ok := entityIDByPublicID[r.Target.ID]
+			if !ok {
+				return fmt.Errorf("missing target entity: relationship=%s entity_public_id=%s", r.ID, r.Target.ID)
+			}
+			relPublicIDs = append(relPublicIDs, r.ID)
+			sourceIDs = append(sourceIDs, sID)
+			targetIDs = append(targetIDs, tID)
+			ranks = append(ranks, r.Strength)
+			descriptions = append(descriptions, r.Description)
+			embeddings = append(embeddings, pgvector.NewVector(relEmb[i]))
+		}
+
+		logger.Debug("[Graph][SaveRelationships] Bulk upserting relationships", "count", len(merged))
+		relRows, err := qtx.UpsertProjectRelationships(ctx, db.UpsertProjectRelationshipsParams{
+			ProjectID:    projectID,
+			SourceIds:    sourceIDs,
+			TargetIds:    targetIDs,
+			Ranks:        ranks,
+			Descriptions: descriptions,
+			Embeddings:   embeddings,
+			PublicIds:    relPublicIDs,
+		})
+		if err != nil {
+			return err
+		}
+
+		relIDByPublicID := make(map[string]int64, len(relRows))
+		for _, r := range relRows {
+			relIDByPublicID[r.PublicID] = r.ID
+			ids = append(ids, r.ID)
+		}
+
+		sources := flattenRelationshipSources(merged, relIDByPublicID)
+		if len(sources) > 0 {
+			err = chunkRange(len(sources), sourceChunk, func(sStart, sEnd int) error {
+				part := sources[sStart:sEnd]
+				logger.Debug("[Graph][SaveRelationships] Saving relationship sources chunk", "sources", len(part))
+
+				unitPublicIDs := make([]string, 0, len(part))
+				for _, src := range part {
+					unitPublicIDs = append(unitPublicIDs, src.unitPublicID)
+				}
+				unitRows, err := qtx.GetTextUnitIDsByPublicIDs(ctx, dedupeStrings(unitPublicIDs))
 				if err != nil {
 					return err
 				}
-				srcEmbed := pgvector.NewVector(srcEmbedding)
+				unitIDByPublicID := make(map[string]int64, len(unitRows))
+				for _, r := range unitRows {
+					unitIDByPublicID[r.PublicID] = r.ID
+				}
 
-				s.dbLock.Lock()
-				defer s.dbLock.Unlock()
-
-				unit, err := qtx.GetTextUnitByPublicId(gCtx, sSrc.Unit.ID)
+				inputs := make([][]byte, len(part))
+				for i := range part {
+					inputs[i] = []byte(part[i].description)
+				}
+				logger.Debug("[Graph][SaveRelationships] Generating relationship source embeddings", "count", len(inputs))
+				embs, err := generateEmbeddings(ctx, s.aiClient, inputs)
 				if err != nil {
 					return err
 				}
 
-				_, err = qtx.AddProjectRelationshipSource(gCtx, db.AddProjectRelationshipSourceParams{
-					PublicID:       sSrc.ID,
-					RelationshipID: id,
-					TextUnitID:     unit.ID,
-					Description:    sSrc.Description,
-					Embedding:      srcEmbed,
+				sPublicIDs := make([]string, 0, len(part))
+				sRelIDs := make([]int64, 0, len(part))
+				sUnitIDs := make([]int64, 0, len(part))
+				sDescriptions := make([]string, 0, len(part))
+				sEmbeddings := make([]pgvector.Vector, 0, len(part))
+				for i := range part {
+					unitID, ok := unitIDByPublicID[part[i].unitPublicID]
+					if !ok {
+						return fmt.Errorf("missing text unit for source: unit_public_id=%s", part[i].unitPublicID)
+					}
+					sPublicIDs = append(sPublicIDs, part[i].publicID)
+					sRelIDs = append(sRelIDs, part[i].relationshipID)
+					sUnitIDs = append(sUnitIDs, unitID)
+					sDescriptions = append(sDescriptions, part[i].description)
+					sEmbeddings = append(sEmbeddings, pgvector.NewVector(embs[i]))
+				}
+
+				logger.Debug("[Graph][SaveRelationships] Bulk upserting relationship sources", "count", len(part))
+				return qtx.UpsertRelationshipSources(ctx, db.UpsertRelationshipSourcesParams{
+					RelationshipIds: sRelIDs,
+					TextUnitIds:     sUnitIDs,
+					Descriptions:    sDescriptions,
+					Embeddings:      sEmbeddings,
+					PublicIds:       sPublicIDs,
 				})
-				if err != nil {
-					return err
-				}
-
-				return nil
 			})
+			if err != nil {
+				return err
+			}
 		}
 
-		if err := eg.Wait(); err != nil {
-			return nil, err
-		}
-
-		ids = append(ids, id)
-	}
-
-	err = trx.Commit(ctx)
+		logger.Debug("[Graph][SaveRelationships] Chunk committed", "relationships", len(merged))
+		return tx.Commit(ctx)
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	return ids, nil
+}
+
+type relationshipSourceRow struct {
+	publicID       string
+	relationshipID int64
+	unitPublicID   string
+	description    string
+}
+
+func mergeRelationshipsByPublicID(in []common.Relationship) []common.Relationship {
+	byID := make(map[string]int, len(in))
+	out := make([]common.Relationship, 0, len(in))
+	for _, r := range in {
+		if r.ID == "" {
+			continue
+		}
+		if idx, ok := byID[r.ID]; ok {
+			if r.Description != "" {
+				out[idx].Description = r.Description
+			}
+			if r.Source != nil {
+				out[idx].Source = r.Source
+			}
+			if r.Target != nil {
+				out[idx].Target = r.Target
+			}
+			out[idx].Strength = r.Strength
+			if len(r.Sources) > 0 {
+				out[idx].Sources = append(out[idx].Sources, r.Sources...)
+			}
+			continue
+		}
+		byID[r.ID] = len(out)
+		out = append(out, r)
+	}
+	return out
+}
+
+func flattenRelationshipSources(relations []common.Relationship, relIDByPublicID map[string]int64) []relationshipSourceRow {
+	rows := make([]relationshipSourceRow, 0)
+	indexByPublicID := make(map[string]int)
+	for _, r := range relations {
+		relID, ok := relIDByPublicID[r.ID]
+		if !ok {
+			continue
+		}
+		for _, src := range r.Sources {
+			if src.ID == "" || src.Unit == nil || src.Unit.ID == "" {
+				continue
+			}
+			row := relationshipSourceRow{
+				publicID:       src.ID,
+				relationshipID: relID,
+				unitPublicID:   src.Unit.ID,
+				description:    src.Description,
+			}
+			if idx, ok := indexByPublicID[row.publicID]; ok {
+				rows[idx] = row
+				continue
+			}
+			indexByPublicID[row.publicID] = len(rows)
+			rows = append(rows, row)
+		}
+	}
+	return rows
 }


### PR DESCRIPTION
## Summary
Implement bulk upsert and chunked ingestion for entities, relationships and text units. Introduce batched embedding generation and transactional chunk commits to improve throughput and reliability when ingesting large datasets. Register pgvector types reliably on connection initialization.
## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional changes)
## Changes Made
- Added SQL upsert and lookup queries: UpsertProjectEntities, UpsertEntitySources, UpsertProjectRelationships, UpsertRelationshipSources, UpsertTextUnits, GetEntityIDsByPublicIDs, GetTextUnitIDsByPublicIDs.
- Added sqlc-generated Go wrappers for the new queries and registered new methods on the Querier interface.
- Switched DB initialization to pgxpool.ParseConfig + pgxpool.NewWithConfig to set AfterConnect and register pgvector types before use (server and worker entrypoints).
- Implemented chunking and deduplication helpers and a batched-embedding path in backend/pkg/store/base/:
  - Chunked transactional upserts for entities, relationships and text units.
  - Merge-by-public-id and flatten source collectors to avoid duplicates.
  - Batched embedding generation with fallback to per-item concurrency when the AI client lacks native batch support.
- Extended AI client interfaces and implementations (OpenAI, Ollama) to support batched and chunked embedding generation, added input normalization, response validation and padding behavior.
- Numerous small fixes: improved error returns, logging, and mapping of public IDs → DB IDs for bulk operations.
## Related Issues
N/A
## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass
## Checklist
- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [x] I have run make generate if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)