### PR TITLE
feat(backend): parallel description generation queue

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -100,7 +100,7 @@ func main() {
 	}
 	defer ch.Close()
 
-	queues := []string{"graph_queue", "delete_queue", "preprocess_queue"}
+	queues := []string{"graph_queue", "delete_queue", "preprocess_queue", "description_queue"}
 	err = queue.SetupQueues(ch, queues)
 
 	logger.Info("Checking for stale batches to recover...")
@@ -179,6 +179,8 @@ func main() {
 					processingErr = queue.ProcessGraphMessage(ctx, client, aiClient, ch, pgConn, string(qm.msg.Body))
 				case "delete_queue":
 					processingErr = queue.ProcessDeleteMessage(ctx, client, aiClient, ch, pgConn, string(qm.msg.Body))
+				case "description_queue":
+					processingErr = queue.ProcessDescriptionMessage(ctx, aiClient, ch, pgConn, string(qm.msg.Body))
 				}
 
 				if processingErr != nil {

--- a/backend/internal/db/models.go
+++ b/backend/internal/db/models.go
@@ -114,6 +114,21 @@ type ProjectBatchStatus struct {
 	ErrorMessage      pgtype.Text        `json:"error_message"`
 }
 
+type ProjectDescriptionJobStatus struct {
+	ID              int64              `json:"id"`
+	ProjectID       int64              `json:"project_id"`
+	CorrelationID   string             `json:"correlation_id"`
+	JobID           int32              `json:"job_id"`
+	TotalJobs       int32              `json:"total_jobs"`
+	EntityIds       []int64            `json:"entity_ids"`
+	RelationshipIds []int64            `json:"relationship_ids"`
+	Status          string             `json:"status"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	StartedAt       pgtype.Timestamptz `json:"started_at"`
+	CompletedAt     pgtype.Timestamptz `json:"completed_at"`
+	ErrorMessage    pgtype.Text        `json:"error_message"`
+}
+
 type ProjectFile struct {
 	ID         int64              `json:"id"`
 	ProjectID  int64              `json:"project_id"`

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -21,12 +21,14 @@ type Querier interface {
 	AddTokenCountToFile(ctx context.Context, arg AddTokenCountToFileParams) error
 	AddUserToGroup(ctx context.Context, arg AddUserToGroupParams) (GroupUser, error)
 	AreAllBatchesCompleted(ctx context.Context, correlationID string) (bool, error)
+	AreAllDescriptionJobsCompleted(ctx context.Context, correlationID string) (bool, error)
 	CleanupOldStagedData(ctx context.Context) error
 	CountCompletedBatches(ctx context.Context, correlationID string) (int32, error)
 	CountEntitySources(ctx context.Context, entityID int64) (int32, error)
 	CountEntitySourcesFromUnits(ctx context.Context, arg CountEntitySourcesFromUnitsParams) (int32, error)
 	CountRelationshipSourcesFromUnits(ctx context.Context, arg CountRelationshipSourcesFromUnitsParams) (int32, error)
 	CreateBatchStatus(ctx context.Context, arg CreateBatchStatusParams) (ProjectBatchStatus, error)
+	CreateDescriptionJobStatus(ctx context.Context, arg CreateDescriptionJobStatusParams) (ProjectDescriptionJobStatus, error)
 	CreateGroup(ctx context.Context, name string) (Group, error)
 	CreateProject(ctx context.Context, arg CreateProjectParams) (Project, error)
 	DeleteBatchStatusByCorrelation(ctx context.Context, correlationID string) error
@@ -64,10 +66,13 @@ type Querier interface {
 	GetBatchStatus(ctx context.Context, arg GetBatchStatusParams) (ProjectBatchStatus, error)
 	GetBatchesByCorrelation(ctx context.Context, correlationID string) ([]ProjectBatchStatus, error)
 	GetDeletedProjectFiles(ctx context.Context, projectID int64) ([]ProjectFile, error)
+	GetDescriptionJobsByCorrelation(ctx context.Context, correlationID string) ([]ProjectDescriptionJobStatus, error)
+	GetEntitiesWithSourcesFromFiles(ctx context.Context, arg GetEntitiesWithSourcesFromFilesParams) ([]GetEntitiesWithSourcesFromFilesRow, error)
 	GetEntitiesWithSourcesFromUnits(ctx context.Context, arg GetEntitiesWithSourcesFromUnitsParams) ([]GetEntitiesWithSourcesFromUnitsRow, error)
 	GetEntityIDsByPublicIDs(ctx context.Context, arg GetEntityIDsByPublicIDsParams) ([]GetEntityIDsByPublicIDsRow, error)
 	GetEntityNeighbours(ctx context.Context, sourceID int64) ([]GetEntityNeighboursRow, error)
 	GetEntityNeighboursRanked(ctx context.Context, arg GetEntityNeighboursRankedParams) ([]GetEntityNeighboursRankedRow, error)
+	GetEntitySourceDescriptionsForFiles(ctx context.Context, arg GetEntitySourceDescriptionsForFilesParams) ([]string, error)
 	GetEntityTypes(ctx context.Context, projectID int64) ([]GetEntityTypesRow, error)
 	GetFilesFromTextUnitIDs(ctx context.Context, dollar_1 []string) ([]GetFilesFromTextUnitIDsRow, error)
 	GetFilesWithMetadataFromTextUnitIDs(ctx context.Context, dollar_1 []string) ([]GetFilesWithMetadataFromTextUnitIDsRow, error)
@@ -92,6 +97,7 @@ type Querier interface {
 	GetProjectEntityWithSourcesFromUnitID(ctx context.Context, textUnitID int64) ([]GetProjectEntityWithSourcesFromUnitIDRow, error)
 	GetProjectFiles(ctx context.Context, projectID int64) ([]ProjectFile, error)
 	GetProjectFilesForBatch(ctx context.Context, dollar_1 []int64) ([]ProjectFile, error)
+	GetProjectFullProgress(ctx context.Context, correlationID string) (GetProjectFullProgressRow, error)
 	GetProjectIDFromTextUnit(ctx context.Context, publicID string) (int64, error)
 	GetProjectRelationshipByEntityIDs(ctx context.Context, arg GetProjectRelationshipByEntityIDsParams) (GetProjectRelationshipByEntityIDsRow, error)
 	GetProjectRelationshipByEntityNames(ctx context.Context, arg GetProjectRelationshipByEntityNamesParams) (GetProjectRelationshipByEntityNamesRow, error)
@@ -105,7 +111,9 @@ type Querier interface {
 	GetProjects(ctx context.Context) ([]Project, error)
 	GetProjectsByGroup(ctx context.Context, groupID int64) ([]Project, error)
 	GetProjectsForUser(ctx context.Context, userID int64) ([]GetProjectsForUserRow, error)
+	GetRelationshipSourceDescriptionsForFiles(ctx context.Context, arg GetRelationshipSourceDescriptionsForFilesParams) ([]string, error)
 	GetRelationshipsByIDs(ctx context.Context, dollar_1 []int64) ([]GetRelationshipsByIDsRow, error)
+	GetRelationshipsWithSourcesFromFiles(ctx context.Context, arg GetRelationshipsWithSourcesFromFilesParams) ([]GetRelationshipsWithSourcesFromFilesRow, error)
 	GetRelationshipsWithSourcesFromUnits(ctx context.Context, arg GetRelationshipsWithSourcesFromUnitsParams) ([]GetRelationshipsWithSourcesFromUnitsRow, error)
 	GetStagedEntities(ctx context.Context, arg GetStagedEntitiesParams) ([][]byte, error)
 	GetStagedRelationships(ctx context.Context, arg GetStagedRelationshipsParams) ([][]byte, error)
@@ -124,6 +132,7 @@ type Querier interface {
 	ReleaseProjectLock(ctx context.Context, dollar_1 int64) error
 	ResetBatchToPending(ctx context.Context, arg ResetBatchToPendingParams) error
 	ResetBatchToPreprocessed(ctx context.Context, arg ResetBatchToPreprocessedParams) error
+	ResetDescriptionJobToPending(ctx context.Context, arg ResetDescriptionJobToPendingParams) error
 	ResetStaleBatchExtractingToPreprocessed(ctx context.Context, id int64) error
 	ResetStaleBatchToPending(ctx context.Context, id int64) error
 	ResetStaleBatchToPreprocessed(ctx context.Context, id int64) error
@@ -133,8 +142,10 @@ type Querier interface {
 	TransferEntitySources(ctx context.Context, arg TransferEntitySourcesParams) error
 	TransferRelationshipSources(ctx context.Context, arg TransferRelationshipSourcesParams) error
 	TryAcquireProjectLock(ctx context.Context, dollar_1 int64) (bool, error)
+	TryStartDescriptionJob(ctx context.Context, arg TryStartDescriptionJobParams) (bool, error)
 	UpdateBatchEstimatedDuration(ctx context.Context, arg UpdateBatchEstimatedDurationParams) error
 	UpdateBatchStatus(ctx context.Context, arg UpdateBatchStatusParams) error
+	UpdateDescriptionJobStatus(ctx context.Context, arg UpdateDescriptionJobStatusParams) error
 	UpdateEntityName(ctx context.Context, arg UpdateEntityNameParams) error
 	UpdateGroup(ctx context.Context, arg UpdateGroupParams) (Group, error)
 	UpdateProject(ctx context.Context, arg UpdateProjectParams) (Project, error)

--- a/backend/internal/db/queries/batch.sql
+++ b/backend/internal/db/queries/batch.sql
@@ -109,3 +109,91 @@ WHERE correlation_id = $1;
 UPDATE project_batch_status
 SET estimated_duration = $3
 WHERE correlation_id = $1 AND batch_id = $2;
+
+-- name: CreateDescriptionJobStatus :one
+INSERT INTO project_description_job_status (
+    project_id, correlation_id, job_id, total_jobs, entity_ids, relationship_ids
+) VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (correlation_id, job_id) DO UPDATE
+SET total_jobs = EXCLUDED.total_jobs,
+    entity_ids = EXCLUDED.entity_ids,
+    relationship_ids = EXCLUDED.relationship_ids
+RETURNING *;
+
+-- name: UpdateDescriptionJobStatus :exec
+UPDATE project_description_job_status
+SET status = $3::text,
+    started_at = CASE WHEN $3::text = 'processing' THEN NOW() ELSE started_at END,
+    completed_at = CASE WHEN $3::text IN ('completed', 'failed') THEN NOW() ELSE completed_at END,
+    error_message = $4
+WHERE correlation_id = $1 AND job_id = $2;
+
+-- name: TryStartDescriptionJob :one
+UPDATE project_description_job_status
+SET status = 'processing',
+    started_at = NOW()
+WHERE correlation_id = $1
+  AND job_id = $2
+  AND status IN ('pending', 'failed')
+RETURNING true;
+
+-- name: ResetDescriptionJobToPending :exec
+UPDATE project_description_job_status
+SET status = 'pending',
+    started_at = NULL,
+    error_message = NULL
+WHERE correlation_id = $1 AND job_id = $2 AND status = 'processing';
+
+-- name: GetDescriptionJobsByCorrelation :many
+SELECT * FROM project_description_job_status
+WHERE correlation_id = $1
+ORDER BY job_id;
+
+-- name: AreAllDescriptionJobsCompleted :one
+SELECT (COUNT(*) FILTER (WHERE status != 'completed') = 0)::bool as all_completed
+FROM project_description_job_status
+WHERE correlation_id = $1;
+
+-- name: GetProjectFullProgress :one
+WITH batch AS (
+    SELECT 
+        COUNT(*) FILTER (WHERE status = 'pending')::int AS pending_count,
+        COUNT(*) FILTER (WHERE status = 'preprocessing')::int AS preprocessing_count,
+        COUNT(*) FILTER (WHERE status = 'preprocessed')::int AS preprocessed_count,
+        COUNT(*) FILTER (WHERE status = 'extracting')::int AS extracting_count,
+        COUNT(*) FILTER (WHERE status = 'indexing')::int AS indexing_count,
+        COUNT(*) FILTER (WHERE status = 'completed')::int AS completed_count,
+        COUNT(*) FILTER (WHERE status = 'failed')::int AS failed_count,
+        COUNT(*)::int AS total_count,
+        COALESCE(SUM(estimated_duration), 0)::bigint AS total_estimated_duration,
+        COALESCE(SUM(estimated_duration) FILTER (WHERE status NOT IN ('completed', 'failed')), 0)::bigint AS remaining_estimated_duration
+    FROM project_batch_status
+    WHERE project_batch_status.correlation_id = $1
+),
+desc_jobs AS (
+    SELECT
+        COUNT(*) FILTER (WHERE status = 'pending')::int AS pending_count,
+        COUNT(*) FILTER (WHERE status = 'processing')::int AS processing_count,
+        COUNT(*) FILTER (WHERE status = 'completed')::int AS completed_count,
+        COUNT(*) FILTER (WHERE status = 'failed')::int AS failed_count,
+        COUNT(*)::int AS total_count
+    FROM project_description_job_status
+    WHERE project_description_job_status.correlation_id = $1
+)
+SELECT
+    batch.pending_count AS batch_pending_count,
+    batch.preprocessing_count AS batch_preprocessing_count,
+    batch.preprocessed_count AS batch_preprocessed_count,
+    batch.extracting_count AS batch_extracting_count,
+    batch.indexing_count AS batch_indexing_count,
+    batch.completed_count AS batch_completed_count,
+    batch.failed_count AS batch_failed_count,
+    batch.total_count AS batch_total_count,
+    batch.total_estimated_duration,
+    batch.remaining_estimated_duration,
+    desc_jobs.pending_count AS description_pending_count,
+    desc_jobs.processing_count AS description_processing_count,
+    desc_jobs.completed_count AS description_completed_count,
+    desc_jobs.failed_count AS description_failed_count,
+    desc_jobs.total_count AS description_total_count
+FROM batch, desc_jobs;

--- a/backend/internal/db/queries/entities.sql
+++ b/backend/internal/db/queries/entities.sql
@@ -168,11 +168,26 @@ SELECT es.id, es.description, es.text_unit_id
 FROM entity_sources es
 WHERE es.entity_id = $1;
 
+-- name: GetEntitySourceDescriptionsForFiles :many
+SELECT es.description
+FROM entity_sources es
+JOIN text_units tu ON tu.id = es.text_unit_id
+WHERE es.entity_id = $1
+  AND tu.project_file_id = ANY($2::bigint[]);
+
 -- name: GetEntitiesWithSourcesFromUnits :many
 SELECT DISTINCT e.id, e.public_id, e.name, e.type, e.description
 FROM entities e
 JOIN entity_sources es ON es.entity_id = e.id
 WHERE es.text_unit_id = ANY($1::bigint[])
+  AND e.project_id = $2;
+
+-- name: GetEntitiesWithSourcesFromFiles :many
+SELECT DISTINCT e.id, e.public_id, e.name, e.type, e.description
+FROM entities e
+JOIN entity_sources es ON es.entity_id = e.id
+JOIN text_units tu ON tu.id = es.text_unit_id
+WHERE tu.project_file_id = ANY($1::bigint[])
   AND e.project_id = $2;
 
 -- name: CountEntitySourcesFromUnits :one

--- a/backend/internal/db/queries/relationships.sql
+++ b/backend/internal/db/queries/relationships.sql
@@ -170,11 +170,26 @@ SELECT rs.id, rs.description, rs.text_unit_id
 FROM relationship_sources rs
 WHERE rs.relationship_id = $1;
 
+-- name: GetRelationshipSourceDescriptionsForFiles :many
+SELECT rs.description
+FROM relationship_sources rs
+JOIN text_units tu ON tu.id = rs.text_unit_id
+WHERE rs.relationship_id = $1
+  AND tu.project_file_id = ANY($2::bigint[]);
+
 -- name: GetRelationshipsWithSourcesFromUnits :many
 SELECT DISTINCT r.id, r.public_id, r.source_id, r.target_id, r.description, r.rank
 FROM relationships r
 JOIN relationship_sources rs ON rs.relationship_id = r.id
 WHERE rs.text_unit_id = ANY($1::bigint[])
+  AND r.project_id = $2;
+
+-- name: GetRelationshipsWithSourcesFromFiles :many
+SELECT DISTINCT r.id, r.public_id, r.source_id, r.target_id, r.description, r.rank
+FROM relationships r
+JOIN relationship_sources rs ON rs.relationship_id = r.id
+JOIN text_units tu ON tu.id = rs.text_unit_id
+WHERE tu.project_file_id = ANY($1::bigint[])
   AND r.project_id = $2;
 
 -- name: CountRelationshipSourcesFromUnits :one

--- a/backend/internal/db/schema.sql
+++ b/backend/internal/db/schema.sql
@@ -233,6 +233,23 @@ CREATE TABLE project_batch_status (
     UNIQUE(correlation_id, batch_id)
 );
 
+-- Track parallel description generation jobs per correlation.
+CREATE TABLE project_description_job_status (
+    id BIGSERIAL PRIMARY KEY,
+    project_id BIGINT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    correlation_id VARCHAR(21) NOT NULL,
+    job_id INT NOT NULL,
+    total_jobs INT NOT NULL,
+    entity_ids BIGINT[] DEFAULT '{}',
+    relationship_ids BIGINT[] DEFAULT '{}',
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    error_message TEXT,
+    UNIQUE(correlation_id, job_id)
+);
+
 -- Unlogged staging table for parallel extraction before lock acquisition.
 CREATE UNLOGGED TABLE extraction_staging (
     id BIGSERIAL PRIMARY KEY,

--- a/backend/internal/queue/handler.go
+++ b/backend/internal/queue/handler.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"path/filepath"
+	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -19,6 +22,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pkoukk/tiktoken-go"
@@ -46,6 +50,15 @@ type QueueProjectFileMsg struct {
 	TotalBatches  int               `json:"total_batches,omitempty"`
 	ProjectFiles  *[]db.ProjectFile `json:"project_files,omitempty"`
 	Operation     string            `json:"operation,omitempty"`
+}
+
+type QueueDescriptionJobMsg struct {
+	ProjectID       int64   `json:"project_id"`
+	CorrelationID   string  `json:"correlation_id"`
+	JobID           int     `json:"job_id"`
+	TotalJobs       int     `json:"total_jobs"`
+	EntityIDs       []int64 `json:"entity_ids,omitempty"`
+	RelationshipIDs []int64 `json:"relationship_ids,omitempty"`
 }
 
 func ProcessGraphMessage(
@@ -368,21 +381,30 @@ func ProcessGraphMessage(
 
 		allDone, checkErr := q.AreAllBatchesCompleted(ctx, data.CorrelationID)
 		if checkErr == nil && allDone {
-			err := FinalizeDescriptionsForCorrelationWithLock(ctx, conn, aiClient, data.CorrelationID)
+			_, err := KickoffDescriptionJobsForCorrelation(ctx, ch, conn, data.CorrelationID, projectId)
 			if err != nil {
-				logger.Error("[Queue] Failed to generate descriptions for correlation", "correlation_id", data.CorrelationID, "err", err)
+				return err
 			}
 
-			latestCorrelationID, latestErr := q.GetLatestCorrelationForProject(ctx, projectId)
-			if latestErr != nil {
-				logger.Warn("[Queue] Failed to fetch latest correlation for project", "project_id", projectId, "correlation_id", data.CorrelationID, "err", latestErr)
-			} else if latestCorrelationID == data.CorrelationID {
-				if _, err := q.UpdateProjectState(ctx, db.UpdateProjectStateParams{ID: projectId, State: "ready"}); err != nil {
-					logger.Error("[Queue] Failed to set project state to ready", "project_id", projectId, "correlation_id", data.CorrelationID, "err", err)
+			descDone, descErr := q.AreAllDescriptionJobsCompleted(ctx, data.CorrelationID)
+			if descErr != nil {
+				return descErr
+			}
+			if descDone {
+				latestCorrelationID, latestErr := q.GetLatestCorrelationForProject(ctx, projectId)
+				if latestErr != nil {
+					logger.Warn("[Queue] Failed to fetch latest correlation for project", "project_id", projectId, "correlation_id", data.CorrelationID, "err", latestErr)
+				} else if latestCorrelationID == data.CorrelationID {
+					if _, err := q.UpdateProjectState(ctx, db.UpdateProjectStateParams{ID: projectId, State: "ready"}); err != nil {
+						logger.Error("[Queue] Failed to set project state to ready", "project_id", projectId, "correlation_id", data.CorrelationID, "err", err)
+					}
 				}
 			}
 		}
 	} else {
+		if err := storageClient.GenerateDescriptions(ctx, files); err != nil {
+			logger.Error("[Queue] Failed to generate descriptions", "project_id", projectId, "err", err)
+		}
 		if _, err := q.UpdateProjectState(ctx, db.UpdateProjectStateParams{ID: projectId, State: "ready"}); err != nil {
 			logger.Error("[Queue] Failed to set project state to ready", "project_id", projectId, "err", err)
 		}
@@ -1040,28 +1062,300 @@ func ResetBatchStatusForRetry(
 	msgBody []byte,
 ) {
 	var data QueueProjectFileMsg
-	if err := json.Unmarshal(msgBody, &data); err != nil {
-		return
-	}
-
-	if data.CorrelationID == "" {
-		return
-	}
+	_ = json.Unmarshal(msgBody, &data)
 
 	q := db.New(conn)
 
 	switch queueName {
 	case "preprocess_queue":
+		if data.CorrelationID == "" {
+			return
+		}
 		_ = q.ResetBatchToPending(ctx, db.ResetBatchToPendingParams{
 			CorrelationID: data.CorrelationID,
 			BatchID:       int32(data.BatchID),
 		})
 	case "graph_queue":
+		if data.CorrelationID == "" {
+			return
+		}
 		_ = q.ResetBatchToPreprocessed(ctx, db.ResetBatchToPreprocessedParams{
 			CorrelationID: data.CorrelationID,
 			BatchID:       int32(data.BatchID),
 		})
+	case "description_queue":
+		var descMsg QueueDescriptionJobMsg
+		if err := json.Unmarshal(msgBody, &descMsg); err != nil {
+			return
+		}
+		if descMsg.CorrelationID == "" {
+			return
+		}
+		_ = q.ResetDescriptionJobToPending(ctx, db.ResetDescriptionJobToPendingParams{
+			CorrelationID: descMsg.CorrelationID,
+			JobID:         int32(descMsg.JobID),
+		})
 	}
+}
+
+func KickoffDescriptionJobsForCorrelation(
+	ctx context.Context,
+	ch *amqp091.Channel,
+	pool *pgxpool.Pool,
+	correlationID string,
+	projectID int64,
+) (int, error) {
+	q := db.New(pool)
+
+	jobs, err := q.GetDescriptionJobsByCorrelation(ctx, correlationID)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(jobs) == 0 {
+		batches, err := q.GetBatchesByCorrelation(ctx, correlationID)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get batches: %w", err)
+		}
+
+		fileIDSet := make(map[int64]struct{})
+		for _, batch := range batches {
+			for _, fid := range batch.FileIds {
+				fileIDSet[fid] = struct{}{}
+			}
+		}
+
+		if len(fileIDSet) == 0 {
+			return 0, nil
+		}
+
+		fileIDs := make([]int64, 0, len(fileIDSet))
+		for fid := range fileIDSet {
+			fileIDs = append(fileIDs, fid)
+		}
+		slices.Sort(fileIDs)
+
+		entities, err := q.GetEntitiesWithSourcesFromFiles(ctx, db.GetEntitiesWithSourcesFromFilesParams{
+			Column1:   fileIDs,
+			ProjectID: projectID,
+		})
+		if err != nil {
+			return 0, fmt.Errorf("failed to get entities: %w", err)
+		}
+		rels, err := q.GetRelationshipsWithSourcesFromFiles(ctx, db.GetRelationshipsWithSourcesFromFilesParams{
+			Column1:   fileIDs,
+			ProjectID: projectID,
+		})
+		if err != nil {
+			return 0, fmt.Errorf("failed to get relationships: %w", err)
+		}
+
+		type item struct {
+			kind string
+			id   int64
+		}
+		items := make([]item, 0, len(entities)+len(rels))
+		for _, e := range entities {
+			items = append(items, item{kind: "entity", id: e.ID})
+		}
+		for _, r := range rels {
+			items = append(items, item{kind: "relationship", id: r.ID})
+		}
+		sort.Slice(items, func(i, j int) bool {
+			if items[i].kind == items[j].kind {
+				return items[i].id < items[j].id
+			}
+			return items[i].kind < items[j].kind
+		})
+
+		jobSize := int(util.GetEnvNumeric("AI_PARALLEL_REQ", 10))
+		totalJobs := (len(items) + jobSize - 1) / jobSize
+		if totalJobs == 0 {
+			return 0, nil
+		}
+
+		for i := range totalJobs {
+			start := i * jobSize
+			end := min(start+jobSize, len(items))
+			chunk := items[start:end]
+
+			entityIDs := make([]int64, 0, len(chunk))
+			relIDs := make([]int64, 0, len(chunk))
+			for _, it := range chunk {
+				switch it.kind {
+				case "entity":
+					entityIDs = append(entityIDs, it.id)
+				case "relationship":
+					relIDs = append(relIDs, it.id)
+				}
+			}
+
+			_, err := q.CreateDescriptionJobStatus(ctx, db.CreateDescriptionJobStatusParams{
+				ProjectID:       projectID,
+				CorrelationID:   correlationID,
+				JobID:           int32(i + 1),
+				TotalJobs:       int32(totalJobs),
+				EntityIds:       entityIDs,
+				RelationshipIds: relIDs,
+			})
+			if err != nil {
+				return 0, fmt.Errorf("failed to create description job status: %w", err)
+			}
+		}
+
+		jobs, err = q.GetDescriptionJobsByCorrelation(ctx, correlationID)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	for _, job := range jobs {
+		if job.Status != "pending" && job.Status != "failed" {
+			continue
+		}
+		msg := QueueDescriptionJobMsg{
+			ProjectID:       job.ProjectID,
+			CorrelationID:   job.CorrelationID,
+			JobID:           int(job.JobID),
+			TotalJobs:       int(job.TotalJobs),
+			EntityIDs:       job.EntityIds,
+			RelationshipIDs: job.RelationshipIds,
+		}
+		b, err := json.Marshal(msg)
+		if err != nil {
+			return len(jobs), err
+		}
+		if err := PublishFIFO(ch, "description_queue", b); err != nil {
+			return len(jobs), err
+		}
+	}
+
+	return len(jobs), nil
+}
+
+func ProcessDescriptionMessage(
+	ctx context.Context,
+	aiClient ai.GraphAIClient,
+	ch *amqp091.Channel,
+	pool *pgxpool.Pool,
+	msg string,
+) error {
+	_ = ch
+	data := new(QueueDescriptionJobMsg)
+	if err := json.Unmarshal([]byte(msg), data); err != nil {
+		return err
+	}
+	if data.CorrelationID == "" {
+		return fmt.Errorf("missing correlation_id")
+	}
+	if data.JobID <= 0 {
+		return fmt.Errorf("invalid job_id")
+	}
+
+	q := db.New(pool)
+	latestCorrelationID, latestErr := q.GetLatestCorrelationForProject(ctx, data.ProjectID)
+	if latestErr == nil && latestCorrelationID != "" && latestCorrelationID != data.CorrelationID {
+		_ = q.UpdateDescriptionJobStatus(ctx, db.UpdateDescriptionJobStatusParams{
+			CorrelationID: data.CorrelationID,
+			JobID:         int32(data.JobID),
+			Column3:       "completed",
+			ErrorMessage:  pgtype.Text{String: "skipped: superseded correlation", Valid: true},
+		})
+		return nil
+	}
+
+	_, err := q.TryStartDescriptionJob(ctx, db.TryStartDescriptionJobParams{
+		CorrelationID: data.CorrelationID,
+		JobID:         int32(data.JobID),
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return err
+	}
+
+	storageClient, err := graphstorage.NewGraphDBStorageWithConnection(ctx, pool, aiClient, []string{})
+	if err != nil {
+		_ = q.UpdateDescriptionJobStatus(ctx, db.UpdateDescriptionJobStatusParams{
+			CorrelationID: data.CorrelationID,
+			JobID:         int32(data.JobID),
+			Column3:       "failed",
+			ErrorMessage:  pgtype.Text{String: err.Error(), Valid: true},
+		})
+		return err
+	}
+
+	batches, err := q.GetBatchesByCorrelation(ctx, data.CorrelationID)
+	if err != nil {
+		return err
+	}
+	fileIDSet := make(map[int64]struct{})
+	for _, b := range batches {
+		for _, fid := range b.FileIds {
+			fileIDSet[fid] = struct{}{}
+		}
+	}
+	fileIDs := make([]int64, 0, len(fileIDSet))
+	for fid := range fileIDSet {
+		fileIDs = append(fileIDs, fid)
+	}
+	slices.Sort(fileIDs)
+
+	if err := storageClient.UpdateEntityDescriptionsByIDsFromFiles(ctx, data.EntityIDs, fileIDs); err != nil {
+		_ = q.UpdateDescriptionJobStatus(ctx, db.UpdateDescriptionJobStatusParams{
+			CorrelationID: data.CorrelationID,
+			JobID:         int32(data.JobID),
+			Column3:       "failed",
+			ErrorMessage:  pgtype.Text{String: err.Error(), Valid: true},
+		})
+		return err
+	}
+	if err := storageClient.UpdateRelationshipDescriptionsByIDsFromFiles(ctx, data.RelationshipIDs, fileIDs); err != nil {
+		_ = q.UpdateDescriptionJobStatus(ctx, db.UpdateDescriptionJobStatusParams{
+			CorrelationID: data.CorrelationID,
+			JobID:         int32(data.JobID),
+			Column3:       "failed",
+			ErrorMessage:  pgtype.Text{String: err.Error(), Valid: true},
+		})
+		return err
+	}
+
+	_ = q.UpdateDescriptionJobStatus(ctx, db.UpdateDescriptionJobStatusParams{
+		CorrelationID: data.CorrelationID,
+		JobID:         int32(data.JobID),
+		Column3:       "completed",
+	})
+
+	allDone, err := q.AreAllDescriptionJobsCompleted(ctx, data.CorrelationID)
+	if err != nil {
+		return err
+	}
+	if !allDone {
+		return nil
+	}
+
+	batchesDone, err := q.AreAllBatchesCompleted(ctx, data.CorrelationID)
+	if err != nil {
+		return err
+	}
+	if !batchesDone {
+		return nil
+	}
+
+	latestCorrelationID, latestErr = q.GetLatestCorrelationForProject(ctx, data.ProjectID)
+	if latestErr != nil {
+		return nil
+	}
+	if latestCorrelationID != data.CorrelationID {
+		return nil
+	}
+
+	if _, err := q.UpdateProjectState(ctx, db.UpdateProjectStateParams{ID: data.ProjectID, State: "ready"}); err != nil {
+		logger.Error("[Queue] Failed to set project state to ready", "project_id", data.ProjectID, "correlation_id", data.CorrelationID, "err", err)
+	}
+
+	return nil
 }
 
 // FinalizeDescriptionsForCorrelation generates descriptions for all entities/relationships

--- a/backend/internal/queue/queue.go
+++ b/backend/internal/queue/queue.go
@@ -47,7 +47,10 @@ func SetupQueues(ch *amqp091.Channel, queueNames []string) error {
 		logger.Fatal("ExchangeDeclare failed", "err", err)
 	}
 
-	queues := []string{"graph_queue", "delete_queue", "preprocess_queue"}
+	queues := queueNames
+	if len(queues) == 0 {
+		queues = []string{"graph_queue", "delete_queue", "preprocess_queue", "description_queue"}
+	}
 	for _, name := range queues {
 		_, err := ch.QueueDeclare(
 			name,

--- a/backend/internal/server/routes/get_projects.go
+++ b/backend/internal/server/routes/get_projects.go
@@ -103,7 +103,7 @@ func GetProjectsHandler(c echo.Context) error {
 		if r.ProjectState != "ready" {
 			correlationID, err := q.GetLatestCorrelationForProject(ctx, r.ProjectID)
 			if err == nil && correlationID != "" {
-				progress, err := q.GetProjectBatchProgress(ctx, correlationID)
+				progress, err := q.GetProjectFullProgress(ctx, correlationID)
 				if err == nil {
 					batchProgress := util.BuildBatchProgress(progress)
 					if batchProgress.Step != nil {

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -73,7 +73,7 @@ func Init() {
 		logger.Fatal("Failed to open channel", "err", err)
 	}
 
-	queues := []string{"index_queue", "update_queue", "delete_queue", "preprocess_queue"}
+	queues := []string{"index_queue", "update_queue", "delete_queue", "preprocess_queue", "description_queue"}
 	err = queue.SetupQueues(ch, queues)
 
 	s3 := storage.NewS3Client(ctx)

--- a/backend/pkg/store/base/bulk.go
+++ b/backend/pkg/store/base/bulk.go
@@ -8,7 +8,7 @@ func chunkRange(total, chunkSize int, fn func(start, end int) error) error {
 		chunkSize = total
 	}
 	for start := 0; start < total; start += chunkSize {
-		end := min(start + chunkSize, total)
+		end := min(start+chunkSize, total)
 		if err := fn(start, end); err != nil {
 			return err
 		}

--- a/migrations/000016_add_description_job_tracking.down.sql
+++ b/migrations/000016_add_description_job_tracking.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS project_description_job_status;

--- a/migrations/000016_add_description_job_tracking.up.sql
+++ b/migrations/000016_add_description_job_tracking.up.sql
@@ -1,0 +1,21 @@
+-- Track parallel description generation jobs for a correlation
+CREATE TABLE project_description_job_status (
+    id BIGSERIAL PRIMARY KEY,
+    project_id BIGINT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    correlation_id VARCHAR(21) NOT NULL,
+    job_id INT NOT NULL,
+    total_jobs INT NOT NULL,
+    entity_ids BIGINT[] DEFAULT '{}',
+    relationship_ids BIGINT[] DEFAULT '{}',
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    error_message TEXT,
+    UNIQUE(correlation_id, job_id)
+);
+
+CREATE INDEX idx_desc_job_status_correlation ON project_description_job_status(correlation_id);
+CREATE INDEX idx_desc_job_status_project ON project_description_job_status(project_id);
+CREATE INDEX idx_desc_job_status_inflight ON project_description_job_status(status)
+    WHERE status IN ('pending', 'processing');


### PR DESCRIPTION
## Summary
Implements a parallel description generation queue system to handle entity and relationship description updates asynchronously. This enhancement improves performance by processing descriptions in parallel batches rather than sequentially.
## Type of Change
- [x] New feature (non-breaking change that adds functionality)
## Changes Made
- Added `description_queue` to RabbitMQ queue configuration
- Created `project_description_job_status` table to track parallel description jobs
- Implemented `QueueDescriptionJobMsg` structure for queue messages
- Added `KickoffDescriptionJobsForCorrelation` function to create and distribute description jobs
- Implemented `ProcessDescriptionMessage` handler for processing individual description jobs
- Enhanced progress tracking to include description job status
- Added database queries for managing description job lifecycle
- Implemented description merging functionality for incremental updates
- Added support for updating descriptions from specific file sources
## Related Issues
Closes #
## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass
## Checklist
- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [x] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)