### PR TITLE
fix(backend): use transaction-scoped advisory locks for deduplication

### DIFF
--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -10,6 +10,7 @@ import (
 
 type Querier interface {
 	AcquireProjectLock(ctx context.Context, dollar_1 int64) error
+	AcquireProjectXactLock(ctx context.Context, dollar_1 int64) error
 	AddFileToProject(ctx context.Context, arg AddFileToProjectParams) (ProjectFile, error)
 	AddProcessTime(ctx context.Context, arg AddProcessTimeParams) error
 	AddProjectEntity(ctx context.Context, arg AddProjectEntityParams) (int64, error)
@@ -148,6 +149,7 @@ type Querier interface {
 	TransferEntitySources(ctx context.Context, arg TransferEntitySourcesParams) error
 	TransferRelationshipSources(ctx context.Context, arg TransferRelationshipSourcesParams) error
 	TryAcquireProjectLock(ctx context.Context, dollar_1 int64) (bool, error)
+	TryAcquireProjectXactLock(ctx context.Context, dollar_1 int64) (bool, error)
 	TryStartDescriptionJob(ctx context.Context, arg TryStartDescriptionJobParams) (bool, error)
 	UpdateBatchEstimatedDuration(ctx context.Context, arg UpdateBatchEstimatedDurationParams) error
 	UpdateBatchStatus(ctx context.Context, arg UpdateBatchStatusParams) error

--- a/backend/internal/db/queries/projects.sql
+++ b/backend/internal/db/queries/projects.sql
@@ -110,3 +110,9 @@ SELECT pg_advisory_unlock($1::bigint);
 
 -- name: TryAcquireProjectLock :one
 SELECT pg_try_advisory_lock($1::bigint) as acquired;
+
+-- name: AcquireProjectXactLock :exec
+SELECT pg_advisory_xact_lock($1::bigint);
+
+-- name: TryAcquireProjectXactLock :one
+SELECT pg_try_advisory_xact_lock($1::bigint) as acquired;


### PR DESCRIPTION
## Summary
Fixes the transaction lock mechanism by switching from session-level advisory locks to transaction-scoped advisory locks (`pg_advisory_xact_lock`). This ensures locks are automatically released when the transaction ends, preventing potential lock leaks. Also includes minor code cleanup.
## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change
## Changes Made
- Added new SQL queries `AcquireProjectXactLock` and `TryAcquireProjectXactLock` using `pg_advisory_xact_lock()` 
- Regenerated sqlc code with new lock methods
- Updated `DedupeAndMergeEntities` to acquire transaction-scoped lock instead of session lock
- Removed redundant comments throughout `dedupe.go`
- Modernized Go code: used `min()` builtin and `range` loops
## Related Issues
N/A
## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass
## Checklist
- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [x] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)
## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->