### PR TITLE
feat(backend): enable clarification questions in agentic queries

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -51,6 +51,9 @@ AI_ADAPTER=openai
 # AI_ADAPTER=ollama
 AI_PARALLEL_REQ=15
 
+# Agentic query: allow clarification questions (default: false)
+AI_ENABLE_QUERY_CLARIFICATION=false
+
 # Note: You can use any compatible API by setting a custom URL:
 # - OpenRouter: https://openrouter.ai/api/v1
 # - Local vLLM/llama.cpp: http://localhost:8000/v1

--- a/README.md
+++ b/README.md
@@ -318,6 +318,14 @@ Copy `.env.sample` to `.env` and configure:
 | `RABBITMQ_HOST`          | RabbitMQ host                      |
 | `RABBITMQ_PORT`          | RabbitMQ port                      |
 
+### Optional: Clarifying Questions (Agentic Queries)
+
+Agentic queries can optionally ask clarifying questions when a user request is
+ambiguous or underspecified.
+
+- `AI_ENABLE_QUERY_CLARIFICATION` (default: `false`): when enabled, the server
+  may return a clarification response instead of attempting a best-guess answer.
+
 Note: When all LDAP variables are set, LDAP sign-in is enabled and email/password auth is disabled.
 
 </details>

--- a/backend/internal/server/routes/post_projects.go
+++ b/backend/internal/server/routes/post_projects.go
@@ -367,7 +367,6 @@ func AddFilesToProjectHandler(c echo.Context) error {
 		keys[key] = file.Filename
 	}
 
-
 	projectFiles := make([]*pgdb.ProjectFile, 0)
 	for key, name := range keys {
 		projectFile, err := q.AddFileToProject(ctx, pgdb.AddFileToProjectParams{
@@ -459,6 +458,8 @@ func AddFilesToProjectHandler(c echo.Context) error {
 
 // QueryProjectHandler handles project queries
 func QueryProjectHandler(c echo.Context) error {
+	const clarificationMarker = "KIWI_CLARIFICATION_REQUIRED"
+
 	type queryProjectRequest struct {
 		ProjectID int64            `param:"id" validate:"required,numeric"`
 		Messages  []ai.ChatMessage `json:"messages" validate:"required"`
@@ -557,6 +558,10 @@ func QueryProjectHandler(c echo.Context) error {
 		opts = append(opts, bqc.WithThinking("high"))
 	}
 
+	if util.GetEnvBool("AI_ENABLE_QUERY_CLARIFICATION", false) {
+		opts = append(opts, bqc.WithClarification(true))
+	}
+
 	queryClient := bqc.NewGraphQueryClient(aiClient, storageClient, fmt.Sprintf("%d", data.ProjectID), opts)
 
 	var answer string
@@ -573,6 +578,16 @@ func QueryProjectHandler(c echo.Context) error {
 		logger.Error("[Query] graph error", "err", err)
 		return c.JSON(http.StatusInternalServerError, queryProjectResponse{
 			Message: "Es ist ein interner Fehler aufgetreten.",
+		})
+	}
+
+	if strings.HasPrefix(answer, clarificationMarker) {
+		answer = strings.TrimLeft(strings.TrimPrefix(answer, clarificationMarker), " \t\r\n")
+		metrics := aiClient.GetMetrics()
+		return c.JSON(http.StatusOK, queryProjectResponse{
+			Message: answer,
+			Data:    []responseData{},
+			Metrics: &metrics,
 		})
 	}
 
@@ -612,6 +627,9 @@ func QueryProjectHandler(c echo.Context) error {
 
 // QueryProjectStreamHandler handles streaming project queries
 func QueryProjectStreamHandler(c echo.Context) error {
+	const clarificationMarker = "KIWI_CLARIFICATION_REQUIRED"
+	const clarificationMarkerLen = len(clarificationMarker)
+
 	type queryProjectRequest struct {
 		ProjectID int64            `param:"id" validate:"required,numeric"`
 		Messages  []ai.ChatMessage `json:"messages" validate:"required"`
@@ -718,6 +736,10 @@ func QueryProjectStreamHandler(c echo.Context) error {
 		opts = append(opts, bqc.WithThinking("high"))
 	}
 
+	if util.GetEnvBool("AI_ENABLE_QUERY_CLARIFICATION", false) {
+		opts = append(opts, bqc.WithClarification(true))
+	}
+
 	c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	c.Response().WriteHeader(http.StatusOK)
 
@@ -749,6 +771,8 @@ func QueryProjectStreamHandler(c echo.Context) error {
 	var messageBuffer strings.Builder
 	var reasoningBuffer strings.Builder
 	var allFoundData []responseData
+	clarificationModeKnown := false
+	clarificationMode := false
 
 	for event := range contentChan {
 		if event.Type == "step" {
@@ -772,6 +796,36 @@ func QueryProjectStreamHandler(c echo.Context) error {
 
 		messageBuffer.WriteString(event.Content)
 		currentMessage := messageBuffer.String()
+
+		if !clarificationModeKnown {
+			if len(currentMessage) < clarificationMarkerLen {
+				// Withhold output until we can decide if this is a clarification response.
+				continue
+			}
+			clarificationModeKnown = true
+			clarificationMode = strings.HasPrefix(currentMessage, clarificationMarker)
+			if clarificationMode {
+				stripped := strings.TrimLeft(strings.TrimPrefix(currentMessage, clarificationMarker), " \t\r\n")
+				messageBuffer.Reset()
+				messageBuffer.WriteString(stripped)
+				currentMessage = stripped
+			}
+		}
+
+		if clarificationMode {
+			resp := streamResponse{
+				Message: currentMessage,
+				Data:    []responseData{},
+			}
+			if reasoningBuffer.Len() > 0 {
+				resp.Reasoning = reasoningBuffer.String()
+			}
+			if err := enc.Encode(resp); err != nil {
+				return err
+			}
+			c.Response().Flush()
+			continue
+		}
 
 		// Check for new data references in the current buffer
 		currentMessage = util.NormalizeIDs(currentMessage)

--- a/backend/pkg/ai/prompts.go
+++ b/backend/pkg/ai/prompts.go
@@ -779,6 +779,40 @@ this full process is complete and you are sure you explored all possibilities.
 - **Strict Prohibition:** You must NOT output a list of entities or IDs at the end of your response. This is a hard constraint.
 `
 
+// ToolQueryClarificationPrompt enables a clarification-first flow for agentic
+// queries. This prompt must only be added when the feature flag is enabled.
+//
+// IMPORTANT: Keep this output plain text (no JSON, no brackets) because the
+// server applies ID-normalization that can mutate bracketed content.
+const ToolQueryClarificationPrompt = `
+# Clarifying Questions (Enabled)
+Clarifying questions are enabled for this conversation.
+
+Before calling ANY tool, decide whether the user's request is ambiguous or
+underspecified in a way that would force you to guess (e.g., missing entity,
+time range, metric, document subset, or target comparison).
+
+If clarification is required:
+- DO NOT call any tools.
+- Ask 1-3 concise, specific, actionable questions.
+- Return ONLY plain text in exactly this format (no extra text):
+
+KIWI_CLARIFICATION_REQUIRED
+1) <question>
+2) <question>
+
+Rules:
+- Write the questions in the same language as the user's latest message.
+- Do not include citations or IDs.
+
+If clarification is not required:
+- Proceed with the normal tool-based retrieval workflow.
+
+If the user answers a previous clarification request:
+- Treat the answer as additional constraints and proceed; do not ask again
+  unless something is still genuinely ambiguous.
+`
+
 const NoDataPrompt = `
 # Task Context
 You are a helpful assistant. The user asked a question, but no relevant information was found in the knowledge base.

--- a/backend/pkg/query/pgx/agentic.go
+++ b/backend/pkg/query/pgx/agentic.go
@@ -19,6 +19,9 @@ func (c *BaseQueryClient) QueryAgentic(
 	aiC := c.aiClient
 
 	systemPrompts := []string{ai.ToolQueryPrompt}
+	if c.options.EnableClarification {
+		systemPrompts = append(systemPrompts, ai.ToolQueryClarificationPrompt)
+	}
 	if len(systemPrompts) > 0 {
 		systemPrompts = append(systemPrompts, c.options.SystemPrompts...)
 	}
@@ -57,6 +60,9 @@ func (c *BaseQueryClient) QueryStreamAgentic(
 		defer close(out)
 
 		systemPrompts := []string{ai.ToolQueryPrompt}
+		if c.options.EnableClarification {
+			systemPrompts = append(systemPrompts, ai.ToolQueryClarificationPrompt)
+		}
 		if len(systemPrompts) > 0 {
 			systemPrompts = append(systemPrompts, c.options.SystemPrompts...)
 		}

--- a/backend/pkg/query/pgx/base.go
+++ b/backend/pkg/query/pgx/base.go
@@ -10,9 +10,10 @@ import (
 )
 
 type queryOptions struct {
-	SystemPrompts []string
-	Model         string
-	Thinking      string
+	SystemPrompts       []string
+	Model               string
+	Thinking            string
+	EnableClarification bool
 }
 
 // QueryOption is a functional option for configuring query behavior.
@@ -39,6 +40,14 @@ func WithModel(model string) QueryOption {
 func WithThinking(thinking string) QueryOption {
 	return func(o *queryOptions) {
 		o.Thinking = thinking
+	}
+}
+
+// WithClarification enables clarification questions in agentic mode.
+// When disabled, query behavior remains unchanged.
+func WithClarification(enabled bool) QueryOption {
+	return func(o *queryOptions) {
+		o.EnableClarification = enabled
 	}
 }
 

--- a/backend/pkg/store/pgx/graphstorage.go
+++ b/backend/pkg/store/pgx/graphstorage.go
@@ -38,6 +38,7 @@ func NewGraphDBStorageWithConnection(
 	return &GraphDBStorage{
 		conn:     conn,
 		aiClient: aiClient,
+		msgs:     msgs,
 		dbLock:   sync.Mutex{},
 	}, nil
 }


### PR DESCRIPTION
## Summary
This PR adds an optional clarification-first flow for agentic project queries. When enabled, the LLM can ask targeted clarifying questions instead of guessing on ambiguous prompts. The behavior is gated behind a feature flag to preserve the existing default query behavior.
## Type of Change
- [x] Feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] CI / Build changes
## Changes Made
- Add a dedicated system prompt to allow “clarification required” responses in agentic mode.
- Wire clarification mode through the query client options (`WithClarification`) and enable it conditionally via `AI_ENABLE_QUERY_CLARIFICATION`.
- Update both non-streaming and streaming project query endpoints to detect a clarification marker and return a clean clarification response (no citations/data expansion), while maintaining normal behavior otherwise.
## Configuration
- Feature flag: `AI_ENABLE_QUERY_CLARIFICATION` (default: disabled)
## Related Issues
Closes #165
## Testing
- [x] `cd backend && go test ./...`
- [x] `cd backend && go build ./...`
- [x] Manual testing of both normal and agentic query modes (streaming + non-streaming)
## Checklist
- [x] Code is formatted (`gofmt`) where applicable
- [x] Tests added/updated where appropriate
- [x] Documentation updated if behavior/configuration changed
- [x] Backwards compatibility preserved when the feature flag is disabled