### PR TITLE
chore(infra): upgrade Postgres to 18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ db-dump:
 		docker run --rm \
 			-v $(ROOT_DIR).backup:/backups \
 			--network kiwi_internal \
-			postgres:17 \
+			postgres:18 \
 			pg_dump "$${DATABASE_URL}" -Fc -f "/backups/$$DUMP_FILE"; \
 		echo "Backup complete: backups/$$DUMP_FILE"
 
@@ -92,7 +92,7 @@ db-restore:
 		docker run --rm \
 			-v $(ROOT_DIR).backup:/backups \
 			--network kiwi_internal \
-			postgres:17 \
+			postgres:18 \
 			pg_restore --clean --if-exists -d "$${DATABASE_URL}" "/backups/$$(basename $$DUMP_PATH)"; \
 		echo "Restore complete"
 

--- a/compose.yml
+++ b/compose.yml
@@ -147,7 +147,7 @@ services:
       POSTGRES_PASSWORD: kiwi
       POSTGRES_DB: kiwi
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U kiwi -d kiwi"]
       interval: 30s

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,4 +1,4 @@
-ARG PG_MAJOR=17
+ARG PG_MAJOR=18
 
 FROM postgres:${PG_MAJOR}-bookworm AS builder
 ARG PG_MAJOR
@@ -22,7 +22,7 @@ RUN set -eux; \
         postgresql-server-dev-${PG_MAJOR}; \
     # Install pgvector
     if ! apt-get install -y --no-install-recommends postgresql-${PG_MAJOR}-pgvector; then \
-        git clone --depth 1 https://github.com/pgvector/pgvector.git /tmp/pgvector; \
+        git clone --depth 1 --branch v0.8.1 https://github.com/pgvector/pgvector.git /tmp/pgvector; \
         make -C /tmp/pgvector; \
         make -C /tmp/pgvector install; \
         rm -rf /tmp/pgvector; \

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -1,0 +1,81 @@
+# Postgres
+
+KIWI ships a custom Postgres image (see `postgres/Dockerfile`) that extends the
+official `postgres` image and includes extensions used by KIWI:
+
+- PostGIS
+- pgRouting
+- pg_cron
+- pgvector
+- vectorscale
+
+## Data Directory / Volume Mount
+
+The upstream `postgres` Docker image changed its data directory layout in
+PostgreSQL 18 and above:
+
+- `PGDATA` is now version specific (for 18: `/var/lib/postgresql/18/docker`)
+- the image declares `VOLUME /var/lib/postgresql`
+
+Because of this, `compose.yml` mounts the database volume at:
+
+```text
+/var/lib/postgresql
+```
+
+Important notes:
+
+- PostgreSQL 17 and below use `PGDATA=/var/lib/postgresql/data` and declare
+  `VOLUME /var/lib/postgresql/data`. If you mount at `/var/lib/postgresql` on 17
+  without setting `PGDATA`, data can end up in an anonymous volume and will not
+  persist across container re-creates.
+- Users who want the new layout on PostgreSQL 17 can opt in by setting
+  `PGDATA=/var/lib/postgresql/17/docker` and mounting the volume at
+  `/var/lib/postgresql`.
+
+## Upgrade: PostgreSQL 17 -> 18 (Existing Production Data)
+
+If you are upgrading an existing production deployment that already has a
+PostgreSQL 17 data volume, you must migrate the data before starting the new
+PostgreSQL 18 container. Otherwise PostgreSQL 18 will initialize an empty
+cluster in `/var/lib/postgresql/18/docker` and your existing 17 cluster will not
+be used.
+
+### Recommended (Safe): Dump + Restore
+
+```bash
+# 1) While still running the old stack, create a backup
+make db-dump
+
+# 2) Stop the stack
+make stop
+
+# 3) Remove ONLY the Postgres volume (after verifying your backup)
+#    Find it first (usually something like "kiwi_postgres_data")
+docker volume ls | grep postgres_data
+
+#    Then remove it
+docker volume rm <your_postgres_volume>
+
+# 4) Build (or pull) the upgraded images
+make build
+
+# 5) Start the upgraded stack (creates a fresh Postgres 18 cluster)
+make start
+
+# 6) Restore the dump
+make db-restore DUMP_FILE=.backup/<your_dump_file>.dump
+
+# 7) Apply migrations
+make migrate
+```
+
+### Advanced: pg_upgrade (Large Datasets)
+
+If you prefer `pg_upgrade`, mount the volume at `/var/lib/postgresql` and move
+the old PostgreSQL 17 cluster into `/var/lib/postgresql/17/docker` before
+running `pg_upgrade`.
+
+You need an environment that has both PostgreSQL 17 and 18 binaries available
+and includes all extensions used by KIWI (PostGIS, pgRouting, pg_cron, pgvector,
+vectorscale).


### PR DESCRIPTION
## Summary
Upgrade the KIWI Postgres container stack to PostgreSQL 18 and document the new upstream data directory/volume behavior to prevent accidental data loss during upgrades.
## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [x] CI/CD or infrastructure change
## Changes Made
- Update the custom Postgres image build to PostgreSQL 18 and pin the pgvector source build to a tagged release for reproducible builds.
- Adjust Compose volume mount path to align with the PostgreSQL 18+ upstream image volume/data directory layout.
- Update `make db-dump` / `make db-restore` to use the PostgreSQL 18 client image.
- Add operational documentation covering the data directory change and recommended upgrade procedure (dump/restore).
## Related Issues
Closes # (no linked issue provided)
## Testing
- [ ] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [ ] All existing tests pass
## Checklist
- [ ] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)
## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->