### PR TITLE
feat(frontend): add copy/play buttons to user messages

### DIFF
--- a/frontend/components/chat/ProjectChat.tsx
+++ b/frontend/components/chat/ProjectChat.tsx
@@ -735,14 +735,8 @@ export function ProjectChat({
                         {message.role === "assistant" && message.metrics && (
                           <>
                             <span>•</span>
-                            <span>{message.metrics.total_tokens} tokens</span>
-                            <span>•</span>
                             <span>
                               {(message.metrics.duration_ms / 1000).toFixed(1)}s
-                            </span>
-                            <span>•</span>
-                            <span>
-                              {message.metrics.tokens_per_second.toFixed(1)} t/s
                             </span>
                           </>
                         )}
@@ -773,6 +767,16 @@ export function ProjectChat({
                               )}
                             </>
                           )}
+                        {message.role === "assistant" && message.metrics && (
+                          <span className="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-2">
+                            <span>•</span>
+                            <span>{message.metrics.total_tokens} tokens</span>
+                            <span>•</span>
+                            <span>
+                              {message.metrics.tokens_per_second.toFixed(1)} t/s
+                            </span>
+                          </span>
+                        )}
                         <span className="opacity-0 group-hover:opacity-100 transition-opacity">
                           •
                         </span>


### PR DESCRIPTION
## Summary

This PR adds "Copy" and "Play" (Text-to-Speech) buttons to user messages in the chat interface, mirroring the functionality previously available only for AI responses. This allows users to easily copy their own past queries or listen to them. The buttons are designed to appear only when hovering over the message to maintain a clean UI.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Modified `ProjectChat.tsx` to render action buttons (Copy, Play) for messages with role `user`.
- Removed `disabled={isAssistantTyping}` restriction from these buttons to allow interaction while the assistant is streaming.
- Implemented hover-only visibility using Tailwind `group` and `group-hover:opacity-100` classes on the button container.
- Applied formatting fixes to `ProjectChat.tsx` and other touched files (`EditProjectDialog.tsx`, `FileStatusIcon.tsx`, `LanguageProvider.tsx`) via `bun run format`.

## Related Issues

Closes #162

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

<img width="268" height="92" alt="image" src="https://github.com/user-attachments/assets/ff068873-69ae-4773-8dbe-c2eef3981a10" />
