### PR TITLE
feat(backend): emit structured citation events in project streaming

### DIFF
--- a/backend/internal/server/routes/post_projects_stream_parser_test.go
+++ b/backend/internal/server/routes/post_projects_stream_parser_test.go
@@ -1,0 +1,107 @@
+package routes
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestStreamCitationParser_EmitsCitationAcrossChunks(t *testing.T) {
+	content, citations := collectParsedStream(t, []string{"Hello [[abc", "123]] world"})
+
+	if content != "Hello  world" {
+		t.Fatalf("unexpected content: %q", content)
+	}
+
+	expectedCitations := []string{"abc123"}
+	if !reflect.DeepEqual(citations, expectedCitations) {
+		t.Fatalf("unexpected citations: got %v want %v", citations, expectedCitations)
+	}
+}
+
+func TestStreamCitationParser_PassesThroughInvalidCitation(t *testing.T) {
+	content, citations := collectParsedStream(t, []string{"Result [[not valid]] token"})
+
+	if content != "Result [[not valid]] token" {
+		t.Fatalf("unexpected content: %q", content)
+	}
+
+	if len(citations) != 0 {
+		t.Fatalf("expected no citations, got %v", citations)
+	}
+}
+
+func TestStreamCitationParser_FlushesIncompleteCitation(t *testing.T) {
+	content, citations := collectParsedStream(t, []string{"prefix [[unfinished"})
+
+	if content != "prefix [[unfinished" {
+		t.Fatalf("unexpected content: %q", content)
+	}
+
+	if len(citations) != 0 {
+		t.Fatalf("expected no citations, got %v", citations)
+	}
+}
+
+func TestStreamCitationParser_HandlesSingleBracketCarry(t *testing.T) {
+	content, citations := collectParsedStream(t, []string{"x [", "[id_1]] y"})
+
+	if content != "x  y" {
+		t.Fatalf("unexpected content: %q", content)
+	}
+
+	expectedCitations := []string{"id_1"}
+	if !reflect.DeepEqual(citations, expectedCitations) {
+		t.Fatalf("unexpected citations: got %v want %v", citations, expectedCitations)
+	}
+}
+
+func TestIsCitationID(t *testing.T) {
+	tests := []struct {
+		name  string
+		id    string
+		valid bool
+	}{
+		{name: "empty", id: "", valid: false},
+		{name: "nanoid chars", id: "abcDEF012_-", valid: true},
+		{name: "space", id: "abc def", valid: false},
+		{name: "bracket", id: "abc]", valid: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isCitationID(tc.id); got != tc.valid {
+				t.Fatalf("isCitationID(%q) = %v, want %v", tc.id, got, tc.valid)
+			}
+		})
+	}
+}
+
+func collectParsedStream(t *testing.T, chunks []string) (string, []string) {
+	t.Helper()
+
+	parser := streamCitationParser{}
+	contentParts := make([]string, 0)
+	citations := make([]string, 0)
+
+	emitContent := func(content string) error {
+		contentParts = append(contentParts, content)
+		return nil
+	}
+	emitCitation := func(citationID string) error {
+		citations = append(citations, citationID)
+		return nil
+	}
+
+	for _, chunk := range chunks {
+		if err := parser.Consume(chunk, emitContent, emitCitation); err != nil {
+			t.Fatalf("consume failed: %v", err)
+		}
+	}
+
+	if err := parser.Flush(emitContent); err != nil {
+		t.Fatalf("flush failed: %v", err)
+	}
+
+	return strings.Join(contentParts, ""), citations
+}


### PR DESCRIPTION
## Summary
This PR improves project query streaming by introducing structured citation event emission and a chunk-aware citation parser that correctly handles citation tokens split across streamed content boundaries. It also adds parser-focused unit tests to validate valid/invalid citation handling and flush behavior.
## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change
## Changes Made
- Added `streamCitationParser` to incrementally parse streamed chunks and emit `content` and `citation` events without leaking citation markers into user-facing content.
- Introduced citation resolution caching and de-duplication during stream processing, with final-pass resolution for any citations present in the normalized final message.
- Added tests in `backend/internal/server/routes/post_projects_stream_parser_test.go` covering cross-chunk citation parsing, invalid citation pass-through, incomplete citation flush behavior, single-bracket carry handling, and citation ID validation.
## Related Issues
N/A
## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass
## Checklist
- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)