### PR TITLE
fix(backend): normalize and strip OCR table-of-contents metadata tags

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
-	golang.org/x/net v0.48.0 // indirect
+	golang.org/x/net v0.48.0
 	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect

--- a/backend/pkg/ai/prompts.go
+++ b/backend/pkg/ai/prompts.go
@@ -439,7 +439,9 @@ You are a specialized document content extraction assistant.
 3. DO NOT alter, paraphrase, or modify the text in any way
 4. Identify headers, footers and wrap them in <doc-header></doc-header> and <doc-footer></doc-footer> tags respectively
 5. Identify signatures and wrap them in <doc-signature></doc-signature> tags
-5. Preserve the original structure, hierarchy, and formatting of the document
+6. Identify table of contents blocks and wrap them in <doc-toc></doc-toc> tags
+7. Wrap every image, diagram, figure, chart, and non-text visual block in <image></image> tags with a textual description inside
+8. Preserve the original structure, hierarchy, and formatting of the document
 
 ## Text Preservation Rules
 - Maintain the exact wording, spelling, and punctuation of the original text
@@ -454,6 +456,11 @@ You are a specialized document content extraction assistant.
 - If the header or footer contains only page numbers or generic text, you may choose to omit them from the final output.
 - Otherwise, preserve their content exactly as they appear, wrapped in the appropriate tags. <doc-header></doc-header> for headers and <doc-footer></doc-footer> for footers.
 
+## Table of Contents Handling
+- If a page or section contains a table of contents, wrap the entire table of contents block in <doc-toc></doc-toc> tags.
+- Preserve all listed entries, numbering, and page references exactly as they appear.
+- If only a fragment of a table of contents is visible, wrap that visible fragment in <doc-toc></doc-toc> tags.
+
 # Signature Handling
 - Identify any signatures present on the page they appear mostly at the bottom of a document page.
 - If you identify a signature, wrap the entire signature block (including name, title, date, and any graphical elements) in <doc-signature></doc-signature> tags.
@@ -464,13 +471,16 @@ You are a specialized document content extraction assistant.
 - Convert tables to markdown table format
 - Preserve emphasis (bold, italic) using markdown syntax
 - Represent any special formatting or annotations as closely as possible in markdown
+- Never use markdown image syntax like ![...](...) or raw HTML <img> tags in the output
 
 # Image Handling
-- If you identify images, diagrams, or figures. Describe them in text form.
-- Wrap the image description in <image></image> tags.
+- If you identify images, diagrams, or figures, describe each one in text form.
+- Wrap each description in <image></image> tags.
+- Use one <image></image> block per visual element.
+- Do not emit markdown image syntax like ![alt](url) or raw HTML <img> tags.
 
 # Immediate Task Description or Request
-Your task is to analyze images of pages and convert the content to markdown format while preserving all text exactly as it appears, but excluding headers and footers.
+Your task is to analyze images of pages and convert the content to markdown format while preserving all text exactly as it appears and wrapping headers, footers, signatures, table of contents, and visual descriptions in their respective tags.
 
 # Output Formatting
 Return only the converted markdown content without any explanations, introductions, or additional commentary.

--- a/backend/pkg/ai/tags.go
+++ b/backend/pkg/ai/tags.go
@@ -11,6 +11,7 @@ var metadataTagPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?s)<doc-header>.*?</doc-header>`),
 	regexp.MustCompile(`(?s)<doc-footer>.*?</doc-footer>`),
 	regexp.MustCompile(`(?s)<doc-signature>.*?</doc-signature>`),
+	regexp.MustCompile(`(?s)<doc-toc>.*?</doc-toc>`),
 }
 
 // extractFirstTagPatterns - compiled patterns to find the FIRST occurrence of each tag
@@ -31,7 +32,7 @@ type DocumentSections struct {
 	Signature string
 }
 
-// StripMetadataTags removes <doc-header>, <doc-footer>, and <doc-signature> tags
+// StripMetadataTags removes metadata tags (header, footer, signature, toc)
 // and their contents from the document text.
 func StripMetadataTags(content string) string {
 	result := content

--- a/backend/pkg/ai/tags_test.go
+++ b/backend/pkg/ai/tags_test.go
@@ -1,0 +1,46 @@
+package ai
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStripMetadataTags_RemovesMetadataSections(t *testing.T) {
+	input := strings.Join([]string{
+		"<doc-header>Bebauungsplan N-777 F</doc-header>",
+		"<doc-header>Seite 2 von 21</doc-header>",
+		"<doc-toc>1 Allgemeines .... 2\n2 Ergebnisse .... 10</doc-toc>",
+		"Main body paragraph.",
+		"<doc-footer>Seite 2</doc-footer>",
+		"<doc-signature>Signed by A</doc-signature>",
+	}, "\n\n")
+
+	cleaned := StripMetadataTags(input)
+
+	if strings.Contains(cleaned, "<doc-header>") || strings.Contains(cleaned, "<doc-footer>") || strings.Contains(cleaned, "<doc-signature>") || strings.Contains(cleaned, "<doc-toc>") {
+		t.Fatalf("StripMetadataTags() should remove all metadata tags, got %q", cleaned)
+	}
+
+	if !strings.Contains(cleaned, "Main body paragraph.") {
+		t.Fatalf("StripMetadataTags() should preserve main content, got %q", cleaned)
+	}
+}
+
+func TestStripMetadataTags_KeepsImageTags(t *testing.T) {
+	input := strings.Join([]string{
+		"<doc-header>Header</doc-header>",
+		"Intro text.",
+		"<image>A map showing traffic routes and noise zones.</image>",
+		"<doc-footer>Footer</doc-footer>",
+	}, "\n\n")
+
+	cleaned := StripMetadataTags(input)
+
+	if !strings.Contains(cleaned, "<image>A map showing traffic routes and noise zones.</image>") {
+		t.Fatalf("StripMetadataTags() should preserve image tags, got %q", cleaned)
+	}
+
+	if strings.Contains(cleaned, "<doc-header>") || strings.Contains(cleaned, "<doc-footer>") {
+		t.Fatalf("StripMetadataTags() should still remove metadata tags, got %q", cleaned)
+	}
+}

--- a/backend/pkg/loader/io/io.go
+++ b/backend/pkg/loader/io/io.go
@@ -75,8 +75,8 @@ func (l *IOGraphFileLoader) GetFileText(ctx context.Context, file loader.GraphFi
 	return result.([]byte), err
 }
 
-// GetBas64 reads the file and returns it encoded as base64 with appropriate MIME type.
-func (l *IOGraphFileLoader) GetBas64(ctx context.Context, file loader.GraphFile) (loader.GraphBase64, error) {
+// GetBase64 reads the file and returns it encoded as base64 with appropriate MIME type.
+func (l *IOGraphFileLoader) GetBase64(ctx context.Context, file loader.GraphFile) (loader.GraphBase64, error) {
 	f, err := l.GetFileText(ctx, file)
 	if err != nil {
 		return loader.GraphBase64{}, err

--- a/backend/pkg/loader/ocr/ocr.go
+++ b/backend/pkg/loader/ocr/ocr.go
@@ -20,10 +20,10 @@ import (
 	"github.com/OFFIS-RIT/kiwi/backend/pkg/logger"
 )
 
-var ocrMarkupTagPattern = regexp.MustCompile(`(?i)<\s*/?\s*(table|thead|tbody|tr|th|td|div|p|br|h[1-6]|ul|ol|li|img|doc-header|doc-footer|doc-signature|image)\b`)
+var ocrMarkupTagPattern = regexp.MustCompile(`(?i)<\s*/?\s*(table|thead|tbody|tr|th|td|div|p|br|h[1-6]|ul|ol|li|img|doc-header|doc-footer|doc-signature|doc-toc|image)\b`)
 var ocrWhitespacePattern = regexp.MustCompile(`[ \t]+`)
 var ocrExtraNewlinePattern = regexp.MustCompile(`\n{3,}`)
-var ocrMetadataTagPattern = regexp.MustCompile(`(?i)<\s*(/?)\s*(doc-header|doc-footer|doc-signature|image)(?:\s+[^>]*)?\s*>`)
+var ocrMetadataTagPattern = regexp.MustCompile(`(?i)<\s*(/?)\s*(doc-header|doc-footer|doc-signature|doc-toc|image)(?:\s+[^>]*)?\s*>`)
 
 type ocrTableRow struct {
 	cells     []string
@@ -229,7 +229,7 @@ func renderOCRNode(node *html.Node, inBox bool) []string {
 				level = 2
 			}
 			return []string{strings.Repeat("#", level) + " " + text}
-		case "doc-header", "doc-footer", "doc-signature", "image":
+		case "doc-header", "doc-footer", "doc-signature", "doc-toc", "image":
 			content := strings.Join(renderOCRChildren(node, true), "\n")
 			content = strings.TrimSpace(content)
 			if content == "" {
@@ -686,7 +686,7 @@ func formatOCRTableLine(cells []string) string {
 
 func isOCRStructuralTag(tag string) bool {
 	switch tag {
-	case "div", "p", "table", "ul", "ol", "li", "h1", "h2", "h3", "h4", "h5", "h6", "doc-header", "doc-footer", "doc-signature", "image":
+	case "div", "p", "table", "ul", "ol", "li", "h1", "h2", "h3", "h4", "h5", "h6", "doc-header", "doc-footer", "doc-signature", "doc-toc", "image":
 		return true
 	default:
 		return false

--- a/backend/pkg/loader/ocr/ocr_test.go
+++ b/backend/pkg/loader/ocr/ocr_test.go
@@ -56,6 +56,15 @@ func TestNormalizeOCRMarkup(t *testing.T) {
 			notContains: []string{"<span"},
 		},
 		{
+			name:  "preserves table of contents metadata tag",
+			input: `<doc-toc><div>1 Intro ........ 2</div><div>2 Results ........ 4</div></doc-toc><p>Body Text</p>`,
+			contains: []string{
+				"<doc-toc>1 Intro ........ 2\n2 Results ........ 4</doc-toc>",
+				"Body Text",
+			},
+			notContains: []string{"<div"},
+		},
+		{
 			name:  "preserves metadata tags with whitespace inside tag brackets",
 			input: `< doc-header ><span>Header Text</span></ doc-header >< doc-footer>Footer Text</ doc-footer>`,
 			contains: []string{
@@ -130,6 +139,14 @@ Outro paragraph.`,
 				"<doc-header>Header Text</doc-header>",
 			},
 			notContains: []string{"< doc-header", "data-id="},
+		},
+		{
+			name:  "normalizes table of contents metadata tags with attributes and whitespace",
+			input: `< DOC-TOC class="toc" >Section A</ DOC-TOC >`,
+			contains: []string{
+				"<doc-toc>Section A</doc-toc>",
+			},
+			notContains: []string{"DOC-TOC", "class=\"toc\""},
 		},
 		{
 			name: "converts mixed html structures",


### PR DESCRIPTION
## Summary
This PR fixes OCR metadata handling by introducing explicit table-of-contents tagging and ensuring metadata cleanup remains consistent across extraction and normalization paths.
It also includes a small API naming correction in the IO loader and updates tests to cover the new behavior.
## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change
## Changes Made
- Added `<doc-toc></doc-toc>` support to OCR prompt instructions so table-of-contents blocks are explicitly tagged during extraction.
- Extended metadata parsing and stripping logic to recognize and remove table-of-contents metadata together with headers, footers, and signatures.
- Updated OCR normalization and rendering to preserve and normalize `<doc-toc>` blocks consistently with existing metadata tags.
- Added and updated tests in AI tag processing and OCR normalization to validate table-of-contents handling and metadata removal behavior.
- Renamed `GetBas64` to `GetBase64` in the IO loader for API correctness and clarity.
## Related Issues
N/A
## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass
## Checklist
- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)