### PR TITLE
feat(frontend): migrate chat to SSE and persisted history

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,6 +1,8 @@
 # Kiwi Frontend - Agent Guidelines
 
-Next.js 16 App Router SPA for knowledge management. Uses TanStack Query for server state, React Context for client state, Radix UI + Tailwind CSS for components.
+Next.js 16 App Router SPA for knowledge management. Uses TanStack Query for
+server state, React Context for client state, Radix UI + Tailwind CSS for
+components.
 
 ## Build Commands
 
@@ -128,7 +130,7 @@ Query keys defined in `queryKeys` object for cache invalidation.
 ### Client (`lib/api/client.ts`)
 
 ```typescript
-import { apiClient, streamRequest, ApiError } from "@/lib/api";
+import { apiClient, streamSSERequest, ApiError } from "@/lib/api";
 
 // Standard requests
 const data = await apiClient.get<ResponseType>("/endpoint");
@@ -140,7 +142,7 @@ await apiClient.delete("/endpoint");
 await apiClient.postFormData("/endpoint", formData);
 
 // Streaming (SSE for chat)
-await streamRequest("/chat", body, onChunk, onError, onComplete);
+await streamSSERequest("/projects/1/stream", body, onEvent, onError);
 ```
 
 ### Error Handling

--- a/frontend/components/chat/ClarificationBlock.tsx
+++ b/frontend/components/chat/ClarificationBlock.tsx
@@ -67,8 +67,14 @@ export function ClarificationBlock({
       )}
       {questions.map((question, i) => (
         <div key={`clarification-q-${i}`} className="space-y-1">
-          <label className="text-sm font-medium">{question}</label>
+          <label
+            className="text-sm font-medium"
+            htmlFor={`clarification-textarea-${i}`}
+          >
+            {question}
+          </label>
           <textarea
+            id={`clarification-textarea-${i}`}
             ref={(el) => {
               inputRefs.current[i] = el;
             }}

--- a/frontend/components/chat/ClarificationBlock.tsx
+++ b/frontend/components/chat/ClarificationBlock.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useLanguage } from "@/providers/LanguageProvider";
+import { Check, SendIcon } from "lucide-react";
+import { useCallback, useRef, useState } from "react";
+
+type ClarificationBlockProps = {
+  questions: string[];
+  reason?: string;
+  onSubmit: (answer: string) => void;
+  disabled?: boolean;
+  /** When true the block is read-only and shows previously submitted answers. */
+  submitted?: boolean;
+  /** Pre-filled answers to display in submitted state. One entry per question. */
+  submittedAnswers?: string[];
+};
+
+/**
+ * Renders clarification questions from the AI and collects user answers.
+ * After submission the block stays visible in a read-only state.
+ */
+export function ClarificationBlock({
+  questions,
+  reason,
+  onSubmit,
+  disabled = false,
+  submitted = false,
+  submittedAnswers,
+}: ClarificationBlockProps) {
+  const { t } = useLanguage();
+  const [answers, setAnswers] = useState<string[]>(
+    () => submittedAnswers ?? new Array(questions.length).fill("")
+  );
+  const inputRefs = useRef<(HTMLTextAreaElement | null)[]>([]);
+
+  const handleSubmit = useCallback(() => {
+    const combined = answers
+      .map((a, i) => `${questions[i]}: ${a}`)
+      .filter((_, i) => answers[i].trim())
+      .join("\n");
+    if (combined.trim()) {
+      onSubmit(combined);
+    }
+  }, [answers, questions, onSubmit]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent, index: number) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        if (index < questions.length - 1) {
+          inputRefs.current[index + 1]?.focus();
+        } else {
+          handleSubmit();
+        }
+      }
+    },
+    [questions.length, handleSubmit]
+  );
+
+  const isDisabled = disabled || submitted;
+
+  return (
+    <div className="mt-3 space-y-3">
+      {reason && (
+        <p className="text-sm text-muted-foreground italic">{reason}</p>
+      )}
+      {questions.map((question, i) => (
+        <div key={`clarification-q-${i}`} className="space-y-1">
+          <label className="text-sm font-medium">{question}</label>
+          <textarea
+            ref={(el) => {
+              inputRefs.current[i] = el;
+            }}
+            className="w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:opacity-60"
+            rows={1}
+            value={submitted ? (submittedAnswers?.[i] ?? "") : answers[i]}
+            onChange={(e) =>
+              setAnswers((prev) => {
+                const next = [...prev];
+                next[i] = e.target.value;
+                return next;
+              })
+            }
+            onKeyDown={(e) => handleKeyDown(e, i)}
+            disabled={isDisabled}
+            placeholder={t("clarification.placeholder")}
+          />
+        </div>
+      ))}
+      <div className="flex justify-end">
+        {submitted ? (
+          <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+            <Check className="h-3 w-3" />
+            {t("clarification.submitted")}
+          </span>
+        ) : (
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={disabled || answers.every((a) => !a.trim())}
+          >
+            <SendIcon className="mr-1 h-3 w-3" />
+            {t("send.message")}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/chat/MessageContent.tsx
+++ b/frontend/components/chat/MessageContent.tsx
@@ -44,6 +44,7 @@ export function MessageContent({
   }, [content, referencePattern]);
 
   const injectBadges = (children: React.ReactNode): React.ReactNode => {
+    let matchCounter = 0;
     const processNode = (node: React.ReactNode): React.ReactNode => {
       if (typeof node === "string") {
         const parts: React.ReactNode[] = [];
@@ -56,9 +57,10 @@ export function MessageContent({
           }
           const id = match[1];
           const idx = createReferenceMapping.get(id) ?? 0;
+          const uniqueKey = `ref-${id}-${matchCounter++}`;
           parts.push(
             <TextReferenceBadge
-              key={`ref-${id}-${idx}`}
+              key={uniqueKey}
               referenceId={id}
               index={idx}
               projectId={projectId}

--- a/frontend/components/chat/index.ts
+++ b/frontend/components/chat/index.ts
@@ -1,7 +1,8 @@
+export { chatTemplates } from "./chat-templates";
+export { ChatTemplateSidebar } from "./ChatTemplateSidebar";
+export { ClarificationBlock } from "./ClarificationBlock";
 export { MessageContent } from "./MessageContent";
 export { ProjectChat } from "./ProjectChat";
 export { ResetChatDialog } from "./ResetChatDialog";
 export { TextReferenceBadge } from "./TextReferenceBadge";
-export { ChatTemplateSidebar } from "./ChatTemplateSidebar";
-export { chatTemplates } from "./chat-templates";
 export { ThinkingDropdown } from "./ThinkingDropdown";

--- a/frontend/components/groups/DeleteGroupDialog.tsx
+++ b/frontend/components/groups/DeleteGroupDialog.tsx
@@ -10,10 +10,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useDeleteGroup } from "@/hooks/use-data";
-import { getChatStorageKey } from "@/lib/utils";
 import { useLanguage } from "@/providers/LanguageProvider";
 import { useNavigation } from "@/providers/NavigationProvider";
-import { useData } from "@/providers/DataProvider";
 import { Loader2 } from "lucide-react";
 import { useEffect } from "react";
 
@@ -33,7 +31,6 @@ export function DeleteGroupDialog({
 }: DeleteGroupDialogProps) {
   const { t } = useLanguage();
   const { showGroups, selectedGroup } = useNavigation();
-  const { groups } = useData();
   const deleteGroupMutation = useDeleteGroup();
 
   useEffect(() => {
@@ -45,15 +42,8 @@ export function DeleteGroupDialog({
   const handleDelete = async () => {
     if (!group) return;
 
-    const groupWithProjects = groups.find((g) => g.id === group.id);
-    const projectIds = groupWithProjects?.projects.map((p) => p.id) ?? [];
-
     try {
       await deleteGroupMutation.mutateAsync(group.id);
-
-      for (const projectId of projectIds) {
-        localStorage.removeItem(getChatStorageKey(projectId));
-      }
 
       onOpenChange(false);
 

--- a/frontend/components/projects/DeleteProjectDialog.tsx
+++ b/frontend/components/projects/DeleteProjectDialog.tsx
@@ -10,7 +10,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useDeleteProject } from "@/hooks/use-data";
-import { getChatStorageKey } from "@/lib/utils";
 import { useLanguage } from "@/providers/LanguageProvider";
 import { useNavigation } from "@/providers/NavigationProvider";
 import { Loader2 } from "lucide-react";
@@ -49,8 +48,6 @@ export function DeleteProjectDialog({
 
     try {
       await deleteProjectMutation.mutateAsync(project.id);
-
-      localStorage.removeItem(getChatStorageKey(project.id));
 
       onOpenChange(false);
 

--- a/frontend/components/projects/ProjectCard.tsx
+++ b/frontend/components/projects/ProjectCard.tsx
@@ -33,7 +33,10 @@ export function ProjectCard({
   const lastUpdated = project.lastUpdated;
   const sourcesCount = project.sourcesCount ?? 0;
   const isProcessing = project.processPercentage !== undefined;
-  const timeRemaining = useCountdown(project.processTimeRemaining, dataUpdatedAt);
+  const timeRemaining = useCountdown(
+    project.processTimeRemaining,
+    dataUpdatedAt
+  );
 
   return (
     <CardTemplate

--- a/frontend/components/sidebar/ProjectProgressChart.tsx
+++ b/frontend/components/sidebar/ProjectProgressChart.tsx
@@ -28,7 +28,10 @@ export function ProjectProgressChart({ project }: ProjectProgressChartProps) {
   const { dataUpdatedAt } = useData();
   const percentage = project.processPercentage ?? 0;
   const step = project.processStep ?? "";
-  const timeRemaining = useCountdown(project.processTimeRemaining, dataUpdatedAt);
+  const timeRemaining = useCountdown(
+    project.processTimeRemaining,
+    dataUpdatedAt
+  );
 
   const chartData = [
     { name: "progress", value: percentage, fill: "var(--foreground)" },

--- a/frontend/hooks/use-data.ts
+++ b/frontend/hooks/use-data.ts
@@ -35,7 +35,7 @@ function parseCount(value?: string): number {
  * "Completed" is never shown. If only completed files remain, falls back to "saving".
  */
 function determineProcessStep(
-  progress?: ApiBatchStepProgress,
+  progress?: ApiBatchStepProgress
 ): ProcessStep | undefined {
   if (!progress) return undefined;
 
@@ -128,8 +128,8 @@ export function useGroupsWithProjects() {
             (project) =>
               project.processPercentage !== undefined &&
               project.processPercentage >= 0 &&
-              project.processPercentage < 100,
-          ),
+              project.processPercentage < 100
+          )
         ) ?? false;
 
       return hasActiveProcessing ? 30000 : false;
@@ -143,7 +143,7 @@ export function useGroupsWithProjects() {
 
       const transformedGroups: Group[] = apiGroups.map((apiGroup) => {
         const groupWithProjects = apiGroupsWithProjects.find(
-          (g) => g.group_id === apiGroup.group_id,
+          (g) => g.group_id === apiGroup.group_id
         );
 
         const projects =
@@ -188,8 +188,8 @@ export function useGroupsWithProjectsSuspense() {
             (project) =>
               project.processPercentage !== undefined &&
               project.processPercentage >= 0 &&
-              project.processPercentage < 100,
-          ),
+              project.processPercentage < 100
+          )
         ) ?? false;
 
       return hasActiveProcessing ? 30000 : false;
@@ -203,7 +203,7 @@ export function useGroupsWithProjectsSuspense() {
 
       const transformedGroups: Group[] = apiGroups.map((apiGroup) => {
         const groupWithProjects = apiGroupsWithProjects.find(
-          (g) => g.group_id === apiGroup.group_id,
+          (g) => g.group_id === apiGroup.group_id
         );
 
         const projects =
@@ -279,15 +279,15 @@ export function useUpdateGroup() {
       });
 
       const previousGroups = queryClient.getQueryData<Group[]>(
-        queryKeys.groupsWithProjects,
+        queryKeys.groupsWithProjects
       );
 
       queryClient.setQueryData<Group[]>(
         queryKeys.groupsWithProjects,
         (old) =>
           old?.map((group) =>
-            group.id === groupId ? { ...group, name } : group,
-          ) || [],
+            group.id === groupId ? { ...group, name } : group
+          ) || []
       );
 
       return { previousGroups };
@@ -296,7 +296,7 @@ export function useUpdateGroup() {
       if (context?.previousGroups) {
         queryClient.setQueryData(
           queryKeys.groupsWithProjects,
-          context.previousGroups,
+          context.previousGroups
         );
       }
     },
@@ -327,12 +327,12 @@ export function useDeleteGroup() {
       });
 
       const previousGroups = queryClient.getQueryData<Group[]>(
-        queryKeys.groupsWithProjects,
+        queryKeys.groupsWithProjects
       );
 
       queryClient.setQueryData<Group[]>(
         queryKeys.groupsWithProjects,
-        (old) => old?.filter((group) => group.id !== groupId) || [],
+        (old) => old?.filter((group) => group.id !== groupId) || []
       );
 
       return { previousGroups };
@@ -341,7 +341,7 @@ export function useDeleteGroup() {
       if (context?.previousGroups) {
         queryClient.setQueryData(
           queryKeys.groupsWithProjects,
-          context.previousGroups,
+          context.previousGroups
         );
       }
     },
@@ -405,7 +405,7 @@ export function useUpdateProject() {
       });
 
       const previousGroups = queryClient.getQueryData<Group[]>(
-        queryKeys.groupsWithProjects,
+        queryKeys.groupsWithProjects
       );
 
       queryClient.setQueryData<Group[]>(
@@ -414,9 +414,9 @@ export function useUpdateProject() {
           old?.map((group) => ({
             ...group,
             projects: group.projects.map((project) =>
-              project.id === projectId ? { ...project, name } : project,
+              project.id === projectId ? { ...project, name } : project
             ),
-          })) || [],
+          })) || []
       );
 
       return { previousGroups };
@@ -425,7 +425,7 @@ export function useUpdateProject() {
       if (context?.previousGroups) {
         queryClient.setQueryData(
           queryKeys.groupsWithProjects,
-          context.previousGroups,
+          context.previousGroups
         );
       }
     },
@@ -455,7 +455,7 @@ export function useDeleteProject() {
       });
 
       const previousGroups = queryClient.getQueryData<Group[]>(
-        queryKeys.groupsWithProjects,
+        queryKeys.groupsWithProjects
       );
 
       queryClient.setQueryData<Group[]>(
@@ -464,9 +464,9 @@ export function useDeleteProject() {
           old?.map((group) => ({
             ...group,
             projects: group.projects.filter(
-              (project) => project.id !== projectId,
+              (project) => project.id !== projectId
             ),
-          })) || [],
+          })) || []
       );
 
       return { previousGroups };
@@ -475,7 +475,7 @@ export function useDeleteProject() {
       if (context?.previousGroups) {
         queryClient.setQueryData(
           queryKeys.groupsWithProjects,
-          context.previousGroups,
+          context.previousGroups
         );
       }
     },
@@ -560,12 +560,12 @@ export function useDeleteProjectFiles() {
       });
 
       const previousFiles = queryClient.getQueryData<ApiProjectFile[]>(
-        queryKeys.projectFiles(projectId),
+        queryKeys.projectFiles(projectId)
       );
 
       queryClient.setQueryData<ApiProjectFile[]>(
         queryKeys.projectFiles(projectId),
-        (old) => old?.filter((file) => !fileKeys.includes(file.file_key)) || [],
+        (old) => old?.filter((file) => !fileKeys.includes(file.file_key)) || []
       );
 
       return { previousFiles, projectId };
@@ -574,7 +574,7 @@ export function useDeleteProjectFiles() {
       if (context?.previousFiles && context.projectId) {
         queryClient.setQueryData(
           queryKeys.projectFiles(context.projectId),
-          context.previousFiles,
+          context.previousFiles
         );
       }
     },

--- a/frontend/lib/api/index.ts
+++ b/frontend/lib/api/index.ts
@@ -3,7 +3,8 @@
  */
 
 // Re-export client utilities
-export { apiClient, ApiError, AUTH_TOKEN, streamRequest } from "./client";
+export { apiClient, ApiError, AUTH_TOKEN, streamSSERequest } from "./client";
+export type { SSEFrame } from "./client";
 
 // Re-export groups API
 export {
@@ -20,24 +21,34 @@ export {
   addFilesToProject,
   createProject,
   deleteProject,
+  deleteProjectChat,
   deleteProjectFiles,
   downloadProjectFile,
+  fetchProjectChat,
+  fetchProjectChats,
   fetchProjectFiles,
   fetchTextUnit,
   queryProject,
   queryProjectStream,
   updateProject,
 } from "./projects";
+export type { StreamEventHandlers } from "./projects";
 
 // Re-export types for convenience
 export type {
-  ApiChatMessage,
+  ApiChatHistoryMessage,
+  ApiChatHistoryResponse,
+  ApiClientToolCall,
+  ApiConversationSummary,
   ApiGroup,
   ApiGroupUser,
   ApiGroupWithProjects,
   ApiProject,
   ApiProjectFile,
-  ApiQueryResponse,
+  ApiProjectQueryRequest,
+  ApiProjectQueryResponse,
+  ApiQueryMetrics,
+  ApiResponseData,
   ApiTextUnit,
   ApiTextUnitResponse,
   QueryMode,

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -5,10 +5,6 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function getChatStorageKey(projectId: string): string {
-  return `chat-history-${projectId}`;
-}
-
 export function formatBytes(bytes: number) {
   if (bytes === 0) return "0 B";
   const k = 1024;

--- a/frontend/providers/LanguageProvider.tsx
+++ b/frontend/providers/LanguageProvider.tsx
@@ -227,6 +227,10 @@ const translations = {
     file: "File:",
     "file.id": "File ID:",
 
+    // Clarification
+    "clarification.placeholder": "Your answer...",
+    "clarification.submitted": "Answers submitted",
+
     // Query Error Boundary
     "error.something.went.wrong": "Something went wrong",
     "error.unexpected.try.again":
@@ -451,6 +455,10 @@ const translations = {
     created: "Erstellt:",
     file: "Datei:",
     "file.id": "Datei-ID:",
+
+    // Clarification
+    "clarification.placeholder": "Ihre Antwort...",
+    "clarification.submitted": "Antworten gesendet",
 
     // Query Error Boundary
     "error.something.went.wrong": "Etwas ist schiefgelaufen",

--- a/frontend/types/api.ts
+++ b/frontend/types/api.ts
@@ -105,14 +105,6 @@ export type ApiGroupUser = {
 };
 
 /**
- * Chat message format for the query API.
- */
-export type ApiChatMessage = {
-  role: "user" | "assistant";
-  message: string;
-};
-
-/**
  * Query speed/depth modes.
  */
 export type QueryMode = "agentic" | "normal";
@@ -132,27 +124,160 @@ export type QueryStep =
   | "get_entity_types"
   | "search_entities_by_type";
 
+// ---------------------------------------------------------------------------
+// Query contract
+// ---------------------------------------------------------------------------
+
 /**
- * Response structure from the /projects/:id/query and /projects/:id/stream endpoints.
+ * Request body for POST /projects/:id/query and POST /projects/:id/stream.
  */
-export type ApiQueryResponse = {
-  step?: QueryStep;
+export type ApiProjectQueryRequest = {
+  prompt: string;
+  conversation_id?: string;
+  mode?: QueryMode;
+  model?: string;
+  think?: boolean;
+  tool_id?: string;
+};
+
+/**
+ * Client-side tool call emitted by the backend when clarification is needed.
+ */
+export type ApiClientToolCall = {
+  tool_call_id: string;
+  tool_name: string;
+  /** JSON-encoded arguments, typically `{ questions: string[], reason?: string }` */
+  tool_arguments: string;
+};
+
+/**
+ * Source file / citation reference returned in query responses.
+ */
+export type ApiResponseData = {
+  id: string;
+  name: string;
+  key: string;
+  text?: string;
+};
+
+/**
+ * Response metrics from query endpoints.
+ */
+export type ApiQueryMetrics = {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  duration_ms: number;
+  wall_clock_ms?: number;
+  tokens_per_second: number;
+};
+
+/**
+ * Non-streaming response from POST /projects/:id/query.
+ */
+export type ApiProjectQueryResponse = {
+  conversation_id: string;
+  message: string;
+  data: ApiResponseData[];
+  client_tool_call?: ApiClientToolCall;
+  reasoning?: string;
+  considered_file_count: number;
+  used_file_count: number;
+};
+
+// ---------------------------------------------------------------------------
+// SSE event payloads for POST /projects/:id/stream
+// ---------------------------------------------------------------------------
+
+export type SSEConversationEvent = {
+  conversation_id: string;
+  is_new: boolean;
+};
+
+export type SSEReasoningEvent = {
+  content: string;
+};
+
+export type SSEContentEvent = {
+  content: string;
+};
+
+export type SSECitationEvent = {
+  id: string;
+  name?: string;
+  key?: string;
+  text?: string;
+};
+
+export type SSEStepEvent = {
+  name: string;
+};
+
+export type SSEToolEvent = {
+  name: string;
+};
+
+export type SSEMetricsEvent = ApiQueryMetrics;
+
+export type SSEDoneEvent = {
+  conversation_id: string;
+  message: string;
+  data: ApiResponseData[];
+  reasoning?: string;
+  client_tool_call?: ApiClientToolCall;
+  used_file_count?: number;
+  considered_file_count?: number;
+};
+
+export type SSEErrorEvent = {
+  message: string;
+};
+
+/**
+ * Discriminated union of all SSE events the frontend handles.
+ */
+export type SSEEvent =
+  | { event: "conversation"; data: SSEConversationEvent }
+  | { event: "reasoning"; data: SSEReasoningEvent }
+  | { event: "content"; data: SSEContentEvent }
+  | { event: "citation"; data: SSECitationEvent }
+  | { event: "step"; data: SSEStepEvent }
+  | { event: "tool"; data: SSEToolEvent }
+  | { event: "client_tool_call"; data: ApiClientToolCall }
+  | { event: "metrics"; data: SSEMetricsEvent }
+  | { event: "done"; data: SSEDoneEvent }
+  | { event: "error"; data: SSEErrorEvent };
+
+// ---------------------------------------------------------------------------
+// Chat history API types
+// ---------------------------------------------------------------------------
+
+/**
+ * Conversation summary from GET /projects/:id/chats.
+ */
+export type ApiConversationSummary = {
+  conversation_id: string;
+  title: string;
+};
+
+/**
+ * Single message in a chat transcript.
+ */
+export type ApiChatHistoryMessage = {
+  role: "user" | "assistant";
   message: string;
   reasoning?: string;
-  data: {
-    id: string;
-    name: string;
-    key: string;
-  }[];
-  metrics?: {
-    input_tokens: number;
-    output_tokens: number;
-    total_tokens: number;
-    duration_ms: number;
-    tokens_per_second: number;
-  };
-  considered_file_count?: number;
-  used_file_count?: number;
+  metrics?: ApiQueryMetrics;
+  data?: ApiResponseData[];
+};
+
+/**
+ * Full chat transcript from GET /projects/:id/chats/:conversation_id.
+ */
+export type ApiChatHistoryResponse = {
+  conversation_id: string;
+  title: string;
+  messages: ApiChatHistoryMessage[];
 };
 
 /**

--- a/frontend/types/api.ts
+++ b/frontend/types/api.ts
@@ -225,8 +225,8 @@ export type SSEDoneEvent = {
   data: ApiResponseData[];
   reasoning?: string;
   client_tool_call?: ApiClientToolCall;
-  used_file_count?: number;
-  considered_file_count?: number;
+  used_file_count: number;
+  considered_file_count: number;
 };
 
 export type SSEErrorEvent = {


### PR DESCRIPTION
## Summary

Migrates the frontend chat to the new backend query contract and real SSE streaming, adds client-side clarification tool-call handling, and hydrates chat history via the new chat history APIs (instead of localStorage).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Implement real SSE streaming parser (`streamSSERequest`) and migrate `queryProjectStream` to event-driven handlers.
- Update chat UI to use `prompt` + `conversation_id`, insert inline citation markers on `citation` events, and handle abrupt EOF/error cases.
- Add clarification tool-call UI block and send follow-up with `tool_id`.
- Hydrate chat transcript from `GET /projects/:id/chats` + `GET /projects/:id/chats/:conversation_id` and reset via `DELETE /projects/:id/chats/:conversation_id`.

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [ ] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [x] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

<img width="1920" height="690" alt="image" src="https://github.com/user-attachments/assets/46e80897-e15d-4da5-a917-eb248bbff2d2" />