### PR TITLE
feat(backend): support client tool-call history in chat retrieval

### DIFF
--- a/backend/internal/server/routes/post_projects.go
+++ b/backend/internal/server/routes/post_projects.go
@@ -600,6 +600,7 @@ func QueryProjectHandler(c echo.Context) error {
 			ToolCallID:    message.ToolCallID,
 			ToolName:      message.ToolName,
 			ToolArguments: message.ToolArguments,
+			ToolExecution: ai.ToolExecution(message.ToolExecution),
 		})
 	}
 
@@ -717,6 +718,7 @@ func QueryProjectHandler(c echo.Context) error {
 				ToolName:      event.Step,
 				ToolCallID:    event.ToolCallID,
 				ToolArguments: event.ToolArguments,
+				ToolExecution: ai.ToolExecutionServer,
 			}
 			if err := serverutil.AppendChatMessage(ctx, q, conversation.ID, toolCall); err != nil {
 				logger.Error("Failed to persist legacy tool call", "err", err)
@@ -728,6 +730,7 @@ func QueryProjectHandler(c echo.Context) error {
 				ToolCallID:    event.ToolCallID,
 				ToolName:      event.ToolName,
 				ToolArguments: event.ToolArguments,
+				ToolExecution: event.ToolExecution,
 			}
 			if err := serverutil.AppendChatMessage(ctx, q, conversation.ID, toolCall); err != nil {
 				logger.Error("Failed to persist tool call", "err", err)
@@ -746,10 +749,11 @@ func QueryProjectHandler(c echo.Context) error {
 				result = event.Content
 			}
 			toolResult := ai.ChatMessage{
-				Role:       "tool",
-				Message:    result,
-				ToolCallID: event.ToolCallID,
-				ToolName:   event.ToolName,
+				Role:          "tool",
+				Message:       result,
+				ToolCallID:    event.ToolCallID,
+				ToolName:      event.ToolName,
+				ToolExecution: event.ToolExecution,
 			}
 			if err := serverutil.AppendChatMessage(ctx, q, conversation.ID, toolResult); err != nil {
 				logger.Error("Failed to persist tool result", "err", err)
@@ -972,6 +976,7 @@ func QueryProjectStreamHandler(c echo.Context) error {
 			ToolCallID:    message.ToolCallID,
 			ToolName:      message.ToolName,
 			ToolArguments: message.ToolArguments,
+			ToolExecution: ai.ToolExecution(message.ToolExecution),
 		})
 	}
 
@@ -1143,6 +1148,7 @@ func QueryProjectStreamHandler(c echo.Context) error {
 				ToolName:      event.Step,
 				ToolCallID:    event.ToolCallID,
 				ToolArguments: event.ToolArguments,
+				ToolExecution: ai.ToolExecutionServer,
 			}
 			if err := serverutil.AppendChatMessage(ctx, q, conversation.ID, toolCall); err != nil {
 				logger.Error("Failed to persist legacy tool call", "err", err)
@@ -1159,6 +1165,7 @@ func QueryProjectStreamHandler(c echo.Context) error {
 				ToolCallID:    event.ToolCallID,
 				ToolName:      event.ToolName,
 				ToolArguments: event.ToolArguments,
+				ToolExecution: event.ToolExecution,
 			}
 			if err := serverutil.AppendChatMessage(ctx, q, conversation.ID, toolCall); err != nil {
 				logger.Error("Failed to persist tool call", "err", err)
@@ -1187,10 +1194,11 @@ func QueryProjectStreamHandler(c echo.Context) error {
 				result = event.Content
 			}
 			toolResult := ai.ChatMessage{
-				Role:       "tool",
-				Message:    result,
-				ToolCallID: event.ToolCallID,
-				ToolName:   event.ToolName,
+				Role:          "tool",
+				Message:       result,
+				ToolCallID:    event.ToolCallID,
+				ToolName:      event.ToolName,
+				ToolExecution: event.ToolExecution,
 			}
 			if err := serverutil.AppendChatMessage(ctx, q, conversation.ID, toolResult); err != nil {
 				logger.Error("Failed to persist tool result", "err", err)

--- a/backend/internal/server/util/chat_helpers_test.go
+++ b/backend/internal/server/util/chat_helpers_test.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestSanitizePostgresText(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "keeps valid text unchanged",
+			input: "hello world",
+			want:  "hello world",
+		},
+		{
+			name:  "removes invalid utf8 bytes",
+			input: string([]byte{'A', 0xe2, '.', '.', 'B'}),
+			want:  "A..B",
+		},
+		{
+			name:  "removes null bytes",
+			input: "prefix\x00suffix",
+			want:  "prefixsuffix",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizePostgresText(tt.input)
+
+			if got != tt.want {
+				t.Fatalf("unexpected sanitized value: got %q, want %q", got, tt.want)
+			}
+
+			if !utf8.ValidString(got) {
+				t.Fatalf("sanitized value must be valid utf-8: %q", got)
+			}
+
+			if strings.Contains(got, "\x00") {
+				t.Fatalf("sanitized value must not contain null bytes: %q", got)
+			}
+		})
+	}
+}

--- a/backend/pkg/ai/ai.go
+++ b/backend/pkg/ai/ai.go
@@ -35,11 +35,12 @@ type ToolCall struct {
 //   - "assistant_tool_call" → assistant requested a tool invocation
 //   - "tool"      → tool result message linked to a tool call
 type ChatMessage struct {
-	Message       string `json:"message"`
-	Role          string `json:"role"`
-	ToolCallID    string `json:"tool_call_id,omitempty"`
-	ToolName      string `json:"tool_name,omitempty"`
-	ToolArguments string `json:"tool_arguments,omitempty"`
+	Message       string        `json:"message"`
+	Role          string        `json:"role"`
+	ToolCallID    string        `json:"tool_call_id,omitempty"`
+	ToolName      string        `json:"tool_name,omitempty"`
+	ToolArguments string        `json:"tool_arguments,omitempty"`
+	ToolExecution ToolExecution `json:"tool_execution,omitempty"`
 }
 
 // GenerateOptions holds configuration for AI generation requests.

--- a/backend/pkg/db/pgx/models.go
+++ b/backend/pkg/db/pgx/models.go
@@ -33,6 +33,7 @@ type ChatMessage struct {
 	ToolCallID    string             `json:"tool_call_id"`
 	ToolName      string             `json:"tool_name"`
 	ToolArguments string             `json:"tool_arguments"`
+	ToolExecution string             `json:"tool_execution"`
 	Reasoning     pgtype.Text        `json:"reasoning"`
 	Metrics       []byte             `json:"metrics"`
 	CreatedAt     pgtype.Timestamptz `json:"created_at"`

--- a/backend/pkg/db/pgx/querier.go
+++ b/backend/pkg/db/pgx/querier.go
@@ -47,7 +47,7 @@ type Querier interface {
 	GetAllProjectsWithGroups(ctx context.Context) ([]GetAllProjectsWithGroupsRow, error)
 	GetBatchesByCorrelation(ctx context.Context, correlationID string) ([]ProjectBatchStatus, error)
 	GetChatMessagesByChatID(ctx context.Context, chatID int64) ([]ChatMessage, error)
-	GetChatMessagesByChatIDWithoutToolCalls(ctx context.Context, chatID int64) ([]ChatMessage, error)
+	GetChatMessagesByChatIDWithoutServerToolCalls(ctx context.Context, chatID int64) ([]ChatMessage, error)
 	GetDeletedProjectFiles(ctx context.Context, projectID int64) ([]ProjectFile, error)
 	GetDescriptionJobsByCorrelation(ctx context.Context, correlationID string) ([]ProjectDescriptionJobStatus, error)
 	GetEntitiesWithSourcesFromFiles(ctx context.Context, arg GetEntitiesWithSourcesFromFilesParams) ([]GetEntitiesWithSourcesFromFilesRow, error)

--- a/backend/pkg/db/pgx/queries/chats.sql
+++ b/backend/pkg/db/pgx/queries/chats.sql
@@ -20,7 +20,7 @@ SET updated_at = NOW()
 WHERE id = sqlc.arg(chat_id)::bigint;
 
 -- name: AddChatMessage :exec
-INSERT INTO chat_messages (chat_id, role, content, tool_call_id, tool_name, tool_arguments, reasoning, metrics)
+INSERT INTO chat_messages (chat_id, role, content, tool_call_id, tool_name, tool_arguments, tool_execution, reasoning, metrics)
 VALUES (
     sqlc.arg(chat_id)::bigint,
     sqlc.arg(role),
@@ -28,6 +28,7 @@ VALUES (
     sqlc.arg(tool_call_id),
     sqlc.arg(tool_name),
     sqlc.arg(tool_arguments),
+    sqlc.arg(tool_execution),
     sqlc.arg(reasoning),
     sqlc.arg(metrics)
 );
@@ -37,10 +38,13 @@ SELECT * FROM chat_messages
 WHERE chat_id = sqlc.arg(chat_id)::bigint
 ORDER BY id ASC;
 
--- name: GetChatMessagesByChatIDWithoutToolCalls :many
+-- name: GetChatMessagesByChatIDWithoutServerToolCalls :many
 SELECT * FROM chat_messages
 WHERE chat_id = sqlc.arg(chat_id)::bigint
-  AND role IN ('user', 'assistant')
+  AND (
+      role IN ('user', 'assistant')
+      OR (role IN ('assistant_tool_call', 'tool') AND tool_execution = 'client')
+  )
 ORDER BY id ASC;
 
 -- name: GetUserChatsByProject :many

--- a/backend/pkg/db/pgx/schema.sql
+++ b/backend/pkg/db/pgx/schema.sql
@@ -203,6 +203,7 @@ CREATE TABLE IF NOT EXISTS chat_messages (
     tool_call_id TEXT NOT NULL DEFAULT '',
     tool_name TEXT NOT NULL DEFAULT '',
     tool_arguments TEXT NOT NULL DEFAULT '',
+    tool_execution TEXT NOT NULL DEFAULT '' CHECK (tool_execution IN ('', 'server', 'client')),
     reasoning TEXT,
     metrics JSONB,
     created_at TIMESTAMPTZ DEFAULT NOW(),
@@ -214,6 +215,9 @@ CREATE INDEX IF NOT EXISTS idx_user_chats_user_project_updated_at
 
 CREATE INDEX IF NOT EXISTS idx_chat_messages_chat_id_id
     ON chat_messages(chat_id, id);
+
+CREATE INDEX IF NOT EXISTS idx_chat_messages_chat_role_execution_id
+    ON chat_messages(chat_id, role, tool_execution, id);
 
 -- Stats Table
 CREATE TABLE IF NOT EXISTS stats (

--- a/migrations/000021_add_chat_tool_execution.down.sql
+++ b/migrations/000021_add_chat_tool_execution.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_chat_messages_chat_role_execution_id;
+
+ALTER TABLE chat_messages
+    DROP CONSTRAINT IF EXISTS chat_messages_tool_execution_check;
+
+ALTER TABLE chat_messages
+    DROP COLUMN IF EXISTS tool_execution;

--- a/migrations/000021_add_chat_tool_execution.up.sql
+++ b/migrations/000021_add_chat_tool_execution.up.sql
@@ -1,0 +1,83 @@
+ALTER TABLE chat_messages
+    ADD COLUMN IF NOT EXISTS tool_execution TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE chat_messages
+    DROP CONSTRAINT IF EXISTS chat_messages_tool_execution_check;
+
+ALTER TABLE chat_messages
+    ADD CONSTRAINT chat_messages_tool_execution_check
+        CHECK (tool_execution IN ('', 'server', 'client'));
+
+-- Backfill assistant tool calls: known graph tools are server-executed.
+-- Unknown tool names are treated as client-executed to avoid hiding
+-- historical client tools from chat history after this migration.
+UPDATE chat_messages
+SET tool_execution = CASE
+    WHEN tool_name = ANY (ARRAY[
+        'search_entities',
+        'search_relationships',
+        'get_entity_neighbours',
+        'get_entity_neighbors',
+        'path_between_entities',
+        'get_entity_sources',
+        'get_relationship_sources',
+        'get_entity_details',
+        'get_relationship_details',
+        'get_entity_types',
+        'search_entities_by_type',
+        'get_source_document_metadata'
+    ]) THEN 'server'
+    ELSE 'client'
+END
+WHERE role = 'assistant_tool_call'
+  AND tool_execution = '';
+
+-- Backfill tool results by inheriting execution from their related tool call.
+-- Fall back to name-based classification when no matching call is found.
+UPDATE chat_messages AS tool_msg
+SET tool_execution = COALESCE(
+    (
+        SELECT call_msg.tool_execution
+        FROM chat_messages AS call_msg
+        WHERE call_msg.chat_id = tool_msg.chat_id
+          AND call_msg.role = 'assistant_tool_call'
+          AND call_msg.tool_call_id = tool_msg.tool_call_id
+          AND call_msg.tool_call_id <> ''
+        ORDER BY call_msg.id DESC
+        LIMIT 1
+    ),
+    CASE
+        WHEN tool_msg.tool_name = ANY (ARRAY[
+            'search_entities',
+            'search_relationships',
+            'get_entity_neighbours',
+            'get_entity_neighbors',
+            'path_between_entities',
+            'get_entity_sources',
+            'get_relationship_sources',
+            'get_entity_details',
+            'get_relationship_details',
+            'get_entity_types',
+            'search_entities_by_type',
+            'get_source_document_metadata'
+        ]) THEN 'server'
+        WHEN tool_msg.tool_name <> '' THEN 'client'
+        ELSE 'server'
+    END
+)
+WHERE tool_msg.role = 'tool'
+  AND tool_msg.tool_execution = '';
+
+UPDATE chat_messages
+SET tool_execution = ''
+WHERE role IN ('user', 'assistant')
+  AND tool_execution = '';
+
+-- Safety fallback for unexpected legacy rows.
+UPDATE chat_messages
+SET tool_execution = 'server'
+WHERE role IN ('assistant_tool_call', 'tool')
+  AND tool_execution = '';
+
+CREATE INDEX IF NOT EXISTS idx_chat_messages_chat_role_execution_id
+    ON chat_messages(chat_id, role, tool_execution, id);


### PR DESCRIPTION
## Summary
This PR introduces tool execution awareness for chat messages so client-executed tool interactions are preserved in chat history responses while server-only tool calls are excluded from user-facing history. It also improves persistence safety by sanitizing invalid UTF-8 and null bytes before storing chat content.
## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change
## Changes Made
- Added `tool_execution` support across chat message model, insert/query SQL, generated pgx code, schema constraints, and migration/indexing.
- Updated project query handlers and chat helper utilities to persist tool execution metadata for tool calls and tool results.
- Reworked chat history assembly to return client tool call metadata/results, include timestamps, and map tool results to their corresponding tool calls.
- Added unit tests for chat text sanitization to ensure stored values are valid UTF-8 and exclude null bytes.
## Related Issues
None specified.
## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass
## Checklist
- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [x] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)
## Screenshots (if applicable)
N/A (backend-only changes).