### PR TITLE
feat(infra): add automatic startup migrations with a dedicated postgres-migration image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Keep root build context minimal for postgres migration image.
+*
+
+!migrations/
+!migrations/**
+
+!postgres/
+!postgres/Dockerfile.migration
+!postgres/run-migrations.sh

--- a/.github/workflows/dev-build-postgres.yml
+++ b/.github/workflows/dev-build-postgres.yml
@@ -7,6 +7,11 @@ on:
       - dev
     paths:
       - 'postgres/**'
+      - 'migrations/**'
+
+concurrency:
+  group: dev-pipeline
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io
@@ -15,11 +20,25 @@ env:
 
 jobs:
   build-images:
-    name: Build and push postgres dev
+    name: Build and push ${{ matrix.name }} dev
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: postgres
+            image: postgres
+            context: ./postgres
+            file: ./postgres/Dockerfile
+            cache: postgres
+          - name: postgres migration
+            image: postgres-migration
+            context: .
+            file: ./postgres/Dockerfile.migration
+            cache: postgres-migration
 
     steps:
       - name: Checkout code
@@ -40,10 +59,10 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v5
         with:
-          path: ${{ runner.temp }}/.buildx-cache-postgres
-          key: docker-${{ runner.os }}-postgres-${{ github.sha }}
+          path: ${{ runner.temp }}/.buildx-cache-${{ matrix.cache }}
+          key: docker-${{ runner.os }}-${{ matrix.cache }}-${{ github.sha }}
           restore-keys: |
-            docker-${{ runner.os }}-postgres-
+            docker-${{ runner.os }}-${{ matrix.cache }}-
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -55,15 +74,15 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
-          context: ./postgres
-          file: ./postgres/Dockerfile
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.IMAGE_PREFIX }}/postgres:${{ env.IMAGE_TAG }}
-          cache-from: type=local,src=${{ runner.temp }}/.buildx-cache-postgres
-          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-postgres-new,mode=max
+          tags: ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}
+          cache-from: type=local,src=${{ runner.temp }}/.buildx-cache-${{ matrix.cache }}
+          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-${{ matrix.cache }}-new,mode=max
 
       - name: Move cache
         run: |
-          rm -rf ${{ runner.temp }}/.buildx-cache-postgres
-          mv ${{ runner.temp }}/.buildx-cache-postgres-new ${{ runner.temp }}/.buildx-cache-postgres
+          rm -rf ${{ runner.temp }}/.buildx-cache-${{ matrix.cache }}
+          mv ${{ runner.temp }}/.buildx-cache-${{ matrix.cache }}-new ${{ runner.temp }}/.buildx-cache-${{ matrix.cache }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -33,6 +33,13 @@ jobs:
             build_args: ""
             tag_suffix: ""
             latest_suffix: ""
+          - name: postgres-migration
+            image: postgres-migration
+            context: .
+            file: ./postgres/Dockerfile.migration
+            cache: postgres-migration
+            target: ""
+            build_args: ""
           - name: server
             image: server
             context: ./backend

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ build:
 	@cd backend && make generate
 	@cd ../
 	@docker build -f postgres/Dockerfile -t ghcr.io/offis-rit/kiwi/postgres:latest ./postgres/
+	@docker build -f postgres/Dockerfile.migration -t ghcr.io/offis-rit/kiwi/postgres-migration:latest .
 	@docker build -f backend/Dockerfile.server -t ghcr.io/offis-rit/kiwi/server:latest ./backend/
 	@docker build -f backend/Dockerfile.worker -t ghcr.io/offis-rit/kiwi/worker:latest ./backend/
 	@docker build -f frontend/Dockerfile -t ghcr.io/offis-rit/kiwi/frontend:latest ./frontend
@@ -11,6 +12,7 @@ build-dev:
 	@cd backend && make generate
 	@cd ../
 	@docker build -f postgres/Dockerfile -t ghcr.io/offis-rit/kiwi/postgres:dev ./postgres/
+	@docker build -f postgres/Dockerfile.migration -t ghcr.io/offis-rit/kiwi/postgres-migration:dev .
 	@docker build -f backend/Dockerfile.server.dev -t ghcr.io/offis-rit/kiwi/server:dev ./backend/
 	@docker build -f backend/Dockerfile.worker.dev -t ghcr.io/offis-rit/kiwi/worker:dev ./backend/
 	@docker build -f frontend/Dockerfile.dev -t ghcr.io/offis-rit/kiwi/frontend:dev ./frontend/

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ The application will be available at:
 - **Frontend**: http://localhost:3000
 - **API**: http://localhost:8080
 
+Database migrations are now applied automatically on startup by the
+`db-migration` container (it runs after `db` is healthy and before backend/auth
+services start).
+
 ### First Time Setup
 
 The `rustfs-setup` container automatically creates the S3 bucket on first start.
@@ -96,7 +100,7 @@ docker exec -it ollama ollama pull <model-name>
 make dev              # Start all services (with logs)
 make dev-backend      # Start without frontend
 make dev-stop         # Stop environment
-make migrate          # Run database migrations
+make migrate          # Run database migrations manually
 ```
 
 ### Services
@@ -145,6 +149,9 @@ make build    # Build Docker images
 make start    # Start production
 make stop     # Stop production
 ```
+
+`make start` also runs the `db-migration` startup container automatically,
+which applies pending migrations before app services connect to the database.
 
 ### SSL/TLS
 

--- a/auth/.dockerignore
+++ b/auth/.dockerignore
@@ -1,0 +1,21 @@
+# Dependencies and build artifacts
+node_modules/
+dist/
+build/
+coverage/
+
+# Tool caches
+.turbo/
+.vercel/
+
+# Local env and debug files
+.env
+.env.*
+*.log
+bun-debug.log*
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS/editor leftovers
+.DS_Store

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,27 @@
+# VCS and editor metadata
+.git
+.jj
+.vscode
+.cursor
+.opencode
+
+# Local env files
+.env
+.env.*
+
+# Build outputs and temporary data
+tmp/
+dist/
+bin/
+graphs/
+coverage/
+
+# Local binaries
+server
+worker
+*.exe
+
+# Logs and local runtime files
+*.log
+*.pid
+*.sock

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -60,6 +60,11 @@ services:
     image: ghcr.io/offis-rit/kiwi/postgres:dev
     ports:
       - "5432:5432"
+  db-migration:
+    build:
+      context: .
+      dockerfile: postgres/Dockerfile.migration
+    image: ghcr.io/offis-rit/kiwi/postgres-migration:dev
   rabbitmq:
     ports:
       - "5672:5672"

--- a/compose.yml
+++ b/compose.yml
@@ -33,6 +33,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      db-migration:
+        condition: service_completed_successfully
   server:
     container_name: server
     build:
@@ -86,6 +88,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      db-migration:
+        condition: service_completed_successfully
       rabbitmq:
         condition: service_healthy
       rustfs:
@@ -133,6 +137,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      db-migration:
+        condition: service_completed_successfully
       rabbitmq:
         condition: service_healthy
       rustfs:
@@ -156,6 +162,19 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+  db-migration:
+    container_name: db-migration
+    image: ghcr.io/offis-rit/kiwi/postgres-migration:latest
+    build:
+      context: .
+      dockerfile: postgres/Dockerfile.migration
+    restart: "no"
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      AI_EMBED_DIM: ${AI_EMBED_DIM:-4096}
+    depends_on:
+      db:
+        condition: service_healthy
   rabbitmq:
     container_name: rabbitmq
     image: rabbitmq:3-management

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,23 @@
+# Dependencies and build artifacts
+node_modules/
+.next/
+out/
+dist/
+build/
+coverage/
+
+# Tool caches
+.turbo/
+.vercel/
+
+# Local env and debug files
+.env
+.env.*
+*.log
+bun-debug.log*
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS/editor leftovers
+.DS_Store

--- a/postgres/.dockerignore
+++ b/postgres/.dockerignore
@@ -1,0 +1,6 @@
+# Keep postgres image context focused on runtime init files.
+*
+
+!Dockerfile
+!db-init/
+!db-init/**

--- a/postgres/Dockerfile.migration
+++ b/postgres/Dockerfile.migration
@@ -1,0 +1,20 @@
+FROM golang:1.25-alpine AS builder
+
+ARG MIGRATE_VERSION=v4.19.0
+ENV CGO_ENABLED=0
+
+RUN go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@${MIGRATE_VERSION}
+
+FROM alpine:3.22
+
+RUN apk add --no-cache ca-certificates gettext postgresql-client
+
+WORKDIR /app
+
+COPY --from=builder /go/bin/migrate /usr/local/bin/migrate
+COPY migrations/ /app/migrations/
+COPY postgres/run-migrations.sh /usr/local/bin/run-migrations.sh
+
+RUN chmod +x /usr/local/bin/run-migrations.sh
+
+ENTRYPOINT ["/usr/local/bin/run-migrations.sh"]

--- a/postgres/run-migrations.sh
+++ b/postgres/run-migrations.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL is required"
+  exit 1
+fi
+
+export AI_EMBED_DIM="${AI_EMBED_DIM:-4096}"
+
+processed_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "${processed_dir}"
+}
+trap cleanup EXIT INT TERM
+
+for file in /app/migrations/*.sql; do
+  [ -f "${file}" ] || continue
+  envsubst '$AI_EMBED_DIM' < "${file}" > "${processed_dir}/$(basename "${file}")"
+done
+
+echo "Waiting for database to be reachable..."
+until pg_isready -d "${DATABASE_URL}" >/dev/null 2>&1; do
+  sleep 2
+done
+
+echo "Applying migrations..."
+migrate -path "${processed_dir}" -database "${DATABASE_URL}" up
+echo "Migrations applied successfully."


### PR DESCRIPTION
## Summary
This PR introduces a dedicated `db-migration` startup container that applies database migrations automatically before dependent services start. It also extends build and release workflows to publish the new `postgres-migration` image and updates documentation to reflect the startup migration flow.
## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [x] CI/CD or infrastructure change
## Changes Made
- Added `postgres/Dockerfile.migration` and `postgres/run-migrations.sh` to package and run `golang-migrate` with database readiness checks and environment-based migration preprocessing.
- Added `db-migration` service definitions in `compose.yml` and `compose.dev.yml`, and updated service dependencies so `auth`, `server`, and `worker` wait for successful migration completion.
- Updated `Makefile` (`build`, `build-dev`) to build `postgres-migration` images for local and CI workflows.
- Updated `.github/workflows/dev-build-postgres.yml` with matrix-based image builds (postgres + postgres-migration), cache separation, and workflow concurrency control.
- Updated `.github/workflows/release-build.yml` to include `postgres-migration` in release image builds.
- Updated `README.md` to document automatic startup migrations and clarify that `make migrate` is a manual operation.
## Related Issues
N/A
## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass
## Checklist
- [ ] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)
