### PR TITLE
fix(backend): persist segmented reasoning around tool calls

### DIFF
--- a/backend/internal/server/routes/get_chats.go
+++ b/backend/internal/server/routes/get_chats.go
@@ -258,7 +258,7 @@ func GetChatHandler(c echo.Context) error {
 			item.ToolName = message.ToolName
 		}
 
-		if message.ToolArguments != "" {
+		if message.ToolArguments != "" && message.ToolExecution == string(ai.ToolExecutionClient) {
 			item.ToolArguments = message.ToolArguments
 		}
 

--- a/backend/internal/server/util/chat_helpers.go
+++ b/backend/internal/server/util/chat_helpers.go
@@ -76,6 +76,12 @@ func AppendChatMessage(ctx context.Context, q *pgdb.Queries, chatID int64, messa
 	toolCallID := sanitizePostgresText(message.ToolCallID)
 	toolName := sanitizePostgresText(message.ToolName)
 	toolArguments := sanitizePostgresText(message.ToolArguments)
+	cleanReasoning := sanitizePostgresText(message.Reasoning)
+
+	reasoningValue := pgtype.Text{}
+	if strings.TrimSpace(cleanReasoning) != "" {
+		reasoningValue = pgtype.Text{String: cleanReasoning, Valid: true}
+	}
 
 	if err := q.AddChatMessage(ctx, pgdb.AddChatMessageParams{
 		ChatID:        chatID,
@@ -85,6 +91,7 @@ func AppendChatMessage(ctx context.Context, q *pgdb.Queries, chatID int64, messa
 		ToolName:      toolName,
 		ToolArguments: toolArguments,
 		ToolExecution: normalizeToolExecution(message.Role, message.ToolExecution),
+		Reasoning:     reasoningValue,
 	}); err != nil {
 		return err
 	}

--- a/backend/pkg/ai/ai.go
+++ b/backend/pkg/ai/ai.go
@@ -41,6 +41,7 @@ type ChatMessage struct {
 	ToolName      string        `json:"tool_name,omitempty"`
 	ToolArguments string        `json:"tool_arguments,omitempty"`
 	ToolExecution ToolExecution `json:"tool_execution,omitempty"`
+	Reasoning     string        `json:"reasoning,omitempty"`
 }
 
 // GenerateOptions holds configuration for AI generation requests.

--- a/backend/pkg/db/pgx/chats.sql.go
+++ b/backend/pkg/db/pgx/chats.sql.go
@@ -156,7 +156,8 @@ SELECT id, chat_id, role, content, tool_call_id, tool_name, tool_arguments, tool
 WHERE chat_id = $1::bigint
   AND (
       role IN ('user', 'assistant')
-      OR (role IN ('assistant_tool_call', 'tool') AND tool_execution = 'client')
+      OR role = 'assistant_tool_call'
+      OR (role = 'tool' AND tool_execution = 'client')
   )
 ORDER BY id ASC
 `

--- a/backend/pkg/db/pgx/queries/chats.sql
+++ b/backend/pkg/db/pgx/queries/chats.sql
@@ -43,7 +43,8 @@ SELECT * FROM chat_messages
 WHERE chat_id = sqlc.arg(chat_id)::bigint
   AND (
       role IN ('user', 'assistant')
-      OR (role IN ('assistant_tool_call', 'tool') AND tool_execution = 'client')
+      OR role = 'assistant_tool_call'
+      OR (role = 'tool' AND tool_execution = 'client')
   )
 ORDER BY id ASC;
 


### PR DESCRIPTION
## Summary
This PR updates chat persistence to store reasoning in segments tied to each assistant tool call, so reasoning generated before a client tool handoff is preserved and can be retrieved later. It also updates chat retrieval to return server and client tool-call entries while keeping server tool execution details private.
## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change
## Changes Made
- Persist per-step reasoning on `assistant_tool_call` rows in both non-streaming and streaming query handlers, and reset the reasoning buffer after each tool call.
- Return the reasoning segment associated with pending client tool calls in early responses, instead of losing pre-tool reasoning.
- Extend chat history filtering to include all `assistant_tool_call` messages (server and client), while still restricting `tool` result visibility to client-executed tools.
- Restrict returned `tool_arguments` in chat history to client tool calls to avoid exposing server execution details.
- Add `Reasoning` support to the chat message model and persistence helper used by chat message inserts.
- Regenerate sqlc output after updating chat query SQL.
## Related Issues
Closes #
## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass
## Checklist
- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [x] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)
## Screenshots (if applicable)
N/A