### PR TITLE
fix(frontend): hydrate chat clarification tool calls

### DIFF
--- a/frontend/types/api.ts
+++ b/frontend/types/api.ts
@@ -264,11 +264,21 @@ export type ApiConversationSummary = {
  * Single message in a chat transcript.
  */
 export type ApiChatHistoryMessage = {
-  role: "user" | "assistant";
+  role: "user" | "assistant" | "assistant_tool_call";
   message: string;
   reasoning?: string;
   metrics?: ApiQueryMetrics;
   data?: ApiResponseData[];
+  tool_call_id?: string;
+  tool_name?: string;
+  tool_arguments?: string;
+  tool_result?: {
+    message?: string;
+    created_at?: string;
+    updated_at?: string;
+  };
+  created_at?: string;
+  updated_at?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary

Hydrates project chat history with persisted tool-call events so clarification prompts and submitted answers survive page reloads. Also attaches tool-call reasoning to the next assistant message for better context.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Parse and restore `ask_clarifying_questions` tool calls from chat history and keep last unsubmitted call as pending.
- Extend `ApiChatHistoryMessage` typing to include `assistant_tool_call` metadata and timestamps.

## Related Issues

Related to #196

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->