### PR TITLE
fix(backend): resolve citation file lookup for internal and source IDs

### DIFF
--- a/backend/pkg/db/pgx/queries/text_units.sql
+++ b/backend/pkg/db/pgx/queries/text_units.sql
@@ -34,17 +34,112 @@ JOIN text_units tu ON tu.project_file_id = f.id
 WHERE tu.public_id = $1;
 
 -- name: GetFilesFromTextUnitIDs :many
-SELECT f.name, f.file_key, tu.public_id FROM project_files f
-JOIN text_units tu
-    ON tu.project_file_id = f.id
-JOIN unnest($1::text[]) AS u(pid)
-    ON tu.public_id = u.pid;
+WITH input_ids AS (
+    SELECT DISTINCT trim(u.pid) AS pid
+    FROM unnest($1::text[]) AS u(pid)
+    WHERE trim(u.pid) <> ''
+),
+numeric_ids AS (
+    SELECT pid, pid::bigint AS id
+    FROM input_ids
+    WHERE pid ~ '^[0-9]+$'
+),
+resolved_text_units AS (
+    SELECT tu.id, tu.public_id, tu.project_file_id
+    FROM input_ids i
+    JOIN text_units tu ON tu.public_id = i.pid
+
+    UNION
+
+    SELECT tu.id, tu.public_id, tu.project_file_id
+    FROM input_ids i
+    JOIN entity_sources es ON es.public_id = i.pid
+    JOIN text_units tu ON tu.id = es.text_unit_id
+
+    UNION
+
+    SELECT tu.id, tu.public_id, tu.project_file_id
+    FROM input_ids i
+    JOIN relationship_sources rs ON rs.public_id = i.pid
+    JOIN text_units tu ON tu.id = rs.text_unit_id
+
+    UNION
+
+    SELECT tu.id, tu.public_id, tu.project_file_id
+    FROM numeric_ids n
+    JOIN text_units tu ON tu.id = n.id
+
+    UNION
+
+    SELECT tu.id, tu.public_id, tu.project_file_id
+    FROM numeric_ids n
+    JOIN entity_sources es ON es.id = n.id
+    JOIN text_units tu ON tu.id = es.text_unit_id
+
+    UNION
+
+    SELECT tu.id, tu.public_id, tu.project_file_id
+    FROM numeric_ids n
+    JOIN relationship_sources rs ON rs.id = n.id
+    JOIN text_units tu ON tu.id = rs.text_unit_id
+)
+SELECT DISTINCT f.name, f.file_key, rtu.public_id
+FROM resolved_text_units rtu
+JOIN project_files f ON f.id = rtu.project_file_id;
 
 -- name: DeleteTextUnitsByFileIDs :exec
 DELETE FROM text_units WHERE project_file_id = ANY($1::bigint[]);
 
 -- name: GetFilesWithMetadataFromTextUnitIDs :many
-SELECT f.name, f.file_key, f.metadata, tu.public_id 
-FROM project_files f
-JOIN text_units tu ON tu.project_file_id = f.id
-JOIN unnest($1::text[]) AS u(pid) ON tu.public_id = u.pid;
+WITH input_ids AS (
+    SELECT DISTINCT trim(u.pid) AS pid
+    FROM unnest($1::text[]) AS u(pid)
+    WHERE trim(u.pid) <> ''
+),
+numeric_ids AS (
+    SELECT pid, pid::bigint AS id
+    FROM input_ids
+    WHERE pid ~ '^[0-9]+$'
+),
+resolved_text_units AS (
+    SELECT tu.id, tu.public_id, tu.project_file_id
+    FROM input_ids i
+    JOIN text_units tu ON tu.public_id = i.pid
+
+    UNION
+
+    SELECT tu.id, tu.public_id, tu.project_file_id
+    FROM input_ids i
+    JOIN entity_sources es ON es.public_id = i.pid
+    JOIN text_units tu ON tu.id = es.text_unit_id
+
+    UNION
+
+    SELECT tu.id, tu.public_id, tu.project_file_id
+    FROM input_ids i
+    JOIN relationship_sources rs ON rs.public_id = i.pid
+    JOIN text_units tu ON tu.id = rs.text_unit_id
+
+    UNION
+
+    SELECT tu.id, tu.public_id, tu.project_file_id
+    FROM numeric_ids n
+    JOIN text_units tu ON tu.id = n.id
+
+    UNION
+
+    SELECT tu.id, tu.public_id, tu.project_file_id
+    FROM numeric_ids n
+    JOIN entity_sources es ON es.id = n.id
+    JOIN text_units tu ON tu.id = es.text_unit_id
+
+    UNION
+
+    SELECT tu.id, tu.public_id, tu.project_file_id
+    FROM numeric_ids n
+    JOIN relationship_sources rs ON rs.id = n.id
+    JOIN text_units tu ON tu.id = rs.text_unit_id
+)
+SELECT DISTINCT f.name, f.file_key, f.metadata, rtu.public_id
+FROM resolved_text_units rtu
+JOIN project_files f ON f.id = rtu.project_file_id;


### PR DESCRIPTION
## Summary
This PR fixes citation source resolution when the LLM returns internal numeric identifiers or source-table identifiers instead of text unit public IDs.  
The backend now resolves citations robustly across text units, entity sources, and relationship sources, then maps them to the correct project files.
## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change
## Changes Made
- Reworked `GetFilesFromTextUnitIDs` to normalize input IDs, parse numeric IDs safely, and resolve through:
  - `text_units` (public/internal IDs)
  - `entity_sources` (public/internal IDs via `text_unit_id`)
  - `relationship_sources` (public/internal IDs via `text_unit_id`)
- Applied the same multi-path resolution strategy to `GetFilesWithMetadataFromTextUnitIDs`.
- Added deduplication with `SELECT DISTINCT` to avoid duplicate file mappings when multiple ID paths resolve to the same text unit.
- Regenerated sqlc output for updated query definitions.
## Related Issues
No linked issue provided.
## Testing
- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass
## Checklist
- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [x] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)
## Screenshots (if applicable)
N/A