### PR TITLE
fix(frontend): prevent long project names from breaking layouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ frontend/.yarn/*
 # testing
 frontend/coverage
 
+# evaluation
+evaluation/
+
 # next.js
 frontend/.next/
 frontend/out/

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -70,12 +70,12 @@ function DashboardContent() {
     <>
       <SidebarInset>
         <header className="flex h-16 shrink-0 items-center justify-between gap-2 border-b px-4">
-          <div className="flex items-center gap-2">
+          <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
             <SidebarTrigger className="-ml-1" />
-            <Separator orientation="vertical" className="mr-2 h-4" />
+            <Separator orientation="vertical" className="mr-2 h-4 shrink-0" />
             <BreadcrumbNav />
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex shrink-0 items-center gap-2">
             <LanguageSwitcher />
             <CreateActions />
             <UserNav />
@@ -83,7 +83,7 @@ function DashboardContent() {
         </header>
         <div className="flex h-[calc(100vh-4rem)] flex-col overflow-hidden p-4">
           {selectedProject && selectedGroup ? (
-            <div className="h-full overflow-hidden">
+            <div className="h-full min-w-0 overflow-hidden">
               <ProjectChat
                 projectName={selectedProject.name}
                 groupName={selectedGroup.name}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ProjectChat } from "@/components/chat";
+import { AppSidebarInset } from "@/components/common";
 import { GroupList } from "@/components/groups";
 import {
   BreadcrumbNav,
@@ -11,7 +12,7 @@ import {
 import { ProjectList } from "@/components/projects";
 import { AppSidebar } from "@/components/sidebar";
 import { Separator } from "@/components/ui/separator";
-import { SidebarInset, SidebarTrigger } from "@/components/ui/sidebar";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 import { AppProviders, useData, useLanguage, useNavigation } from "@/providers";
 import type { Group, Project } from "@/types";
 import { Suspense, lazy, useState } from "react";
@@ -68,7 +69,7 @@ function DashboardContent() {
 
   return (
     <>
-      <SidebarInset>
+      <AppSidebarInset>
         <header className="flex h-16 shrink-0 items-center justify-between gap-2 border-b px-4">
           <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
             <SidebarTrigger className="-ml-1" />
@@ -111,7 +112,7 @@ function DashboardContent() {
             </div>
           )}
         </div>
-      </SidebarInset>
+      </AppSidebarInset>
 
       <Suspense fallback={null}>
         <EditProjectDialog

--- a/frontend/components/chat/ProjectChat.tsx
+++ b/frontend/components/chat/ProjectChat.tsx
@@ -281,6 +281,7 @@ export function ProjectChat({
   projectId,
 }: ProjectChatProps) {
   const { t, language } = useLanguage();
+  const groupDescription = `${t("from.group")} ${groupName} ${t("group")}`;
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputValue, setInputValue] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -919,11 +920,17 @@ export function ProjectChat({
       <div className="mb-4 min-w-0 shrink-0">
         <div className="flex min-w-0 items-start justify-between gap-4">
           <div className="min-w-0 flex-1 overflow-hidden">
-            <h1 className="max-w-full truncate text-2xl font-bold">
+            <h1
+              className="max-w-full truncate text-2xl font-bold"
+              title={projectName}
+            >
               {projectName}
             </h1>
-            <p className="max-w-full truncate text-muted-foreground">
-              {t("from.group")} {groupName} {t("group")}
+            <p
+              className="max-w-full truncate text-muted-foreground"
+              title={groupDescription}
+            >
+              {groupDescription}
             </p>
           </div>
 

--- a/frontend/components/chat/ProjectChat.tsx
+++ b/frontend/components/chat/ProjectChat.tsx
@@ -915,24 +915,26 @@ export function ProjectChat({
   }, [displayedInputValue, adjustTextareaHeight]);
 
   return (
-    <div className="flex h-[calc(100vh-6rem)] flex-col overflow-hidden">
-      <div className="mb-4 flex-shrink-0">
-        <div className="flex justify-between gap-2">
-          <div className="flex-1">
-            <h1 className="text-2xl font-bold">{projectName}</h1>
-            <p className="text-muted-foreground">
+    <div className="flex h-[calc(100vh-6rem)] min-w-0 flex-col overflow-hidden">
+      <div className="mb-4 min-w-0 shrink-0">
+        <div className="flex min-w-0 items-start justify-between gap-4">
+          <div className="min-w-0 flex-1 overflow-hidden">
+            <h1 className="max-w-full truncate text-2xl font-bold">
+              {projectName}
+            </h1>
+            <p className="max-w-full truncate text-muted-foreground">
               {t("from.group")} {groupName} {t("group")}
             </p>
           </div>
 
-          <div className="flex items-end gap-2">
+          <div className="flex shrink-0 items-end gap-2">
             <div className="flex flex-col gap-0.5">
               <Label className="text-xs text-muted-foreground">Mode</Label>
               <Select
                 value={selectedMode}
                 onValueChange={(value: QueryMode) => setSelectedMode(value)}
               >
-                <SelectTrigger className="w-28 h-8">
+                <SelectTrigger className="h-8 w-28">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -951,7 +953,7 @@ export function ProjectChat({
                   setUseThink(value.includes("Thinking"));
                 }}
               >
-                <SelectTrigger className="w-56 h-8">
+                <SelectTrigger className="h-8 w-56">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -1215,7 +1217,7 @@ export function ProjectChat({
                 value={displayedInputValue}
                 onChange={(e) => setInputValue(e.target.value)}
                 onKeyDown={handleKeyDown}
-                className={`flex-1 resize-none overflow-hidden border-input min-h-[2.5rem] w-full min-w-0 rounded-md border bg-transparent px-3 py-2 text-base shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm ${isRecording && interimTranscript ? "text-muted-foreground" : ""}`}
+                className={`flex-1 resize-none overflow-hidden border-input min-h-10 w-full min-w-0 rounded-md border bg-transparent px-3 py-2 text-base shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm ${isRecording && interimTranscript ? "text-muted-foreground" : ""}`}
                 disabled={isRecording || !!pendingToolCall}
                 rows={1}
               />

--- a/frontend/components/common/AppSidebarInset.tsx
+++ b/frontend/components/common/AppSidebarInset.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { SidebarInset } from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
+
+export function AppSidebarInset({
+  className,
+  ...props
+}: React.ComponentProps<typeof SidebarInset>) {
+  return <SidebarInset className={cn("min-w-0", className)} {...props} />;
+}

--- a/frontend/components/common/CardTemplate.tsx
+++ b/frontend/components/common/CardTemplate.tsx
@@ -42,15 +42,21 @@ export function CardTemplate({
   const { t } = useLanguage();
 
   return (
-    <Card className="flex h-full min-h-[255px] flex-col gap-0 overflow-hidden pb-0 transition-all hover:shadow-md">
-      <CardHeader className="px-6 pb-4 min-h-[76px]">
-        <CardTitle className="text-lg font-semibold">{title}</CardTitle>
-        {description && <CardDescription>{description}</CardDescription>}
+    <Card className="flex h-full min-h-[255px] min-w-0 flex-col gap-0 overflow-hidden pb-0 transition-all hover:shadow-md">
+      <CardHeader className="min-w-0 px-6 pb-4 min-h-[76px]">
+        <CardTitle className="min-w-0 truncate text-lg font-semibold">
+          {title}
+        </CardTitle>
+        {description && (
+          <CardDescription className="min-w-0 truncate">
+            {description}
+          </CardDescription>
+        )}
       </CardHeader>
       <CardContent className="flex-1 px-6 pb-6 min-h-[80px]">
         {children}
       </CardContent>
-      <CardFooter className="flex items-center justify-between border-t bg-muted/50 px-6 py-3 !pt-3">
+      <CardFooter className="flex items-center justify-between border-t bg-muted/50 px-6 py-3 pt-3!">
         <Badge variant="outline" className="bg-background">
           <BadgeIcon className="mr-1 h-3 w-3" />
           {badgeText}

--- a/frontend/components/common/CardTemplate.tsx
+++ b/frontend/components/common/CardTemplate.tsx
@@ -44,11 +44,14 @@ export function CardTemplate({
   return (
     <Card className="flex h-full min-h-[255px] min-w-0 flex-col gap-0 overflow-hidden pb-0 transition-all hover:shadow-md">
       <CardHeader className="min-w-0 px-6 pb-4 min-h-[76px]">
-        <CardTitle className="min-w-0 truncate text-lg font-semibold">
+        <CardTitle
+          className="min-w-0 truncate text-lg font-semibold"
+          title={title}
+        >
           {title}
         </CardTitle>
         {description && (
-          <CardDescription className="min-w-0 truncate">
+          <CardDescription className="min-w-0 truncate" title={description}>
             {description}
           </CardDescription>
         )}

--- a/frontend/components/common/index.ts
+++ b/frontend/components/common/index.ts
@@ -1,3 +1,4 @@
+export { AppSidebarInset } from "./AppSidebarInset";
 export { CardTemplate } from "./CardTemplate";
 export { LoadingFallback } from "./LoadingFallback";
 export { StateDisplay } from "./StateDisplay";

--- a/frontend/components/header/BreadcrumbNav.tsx
+++ b/frontend/components/header/BreadcrumbNav.tsx
@@ -22,16 +22,17 @@ export function BreadcrumbNav() {
   const { t } = useLanguage();
 
   return (
-    <Breadcrumb>
-      <BreadcrumbList>
+    <Breadcrumb className="min-w-0 w-full overflow-hidden">
+      <BreadcrumbList className="min-w-0 w-full flex-nowrap overflow-hidden">
         {showAllGroups ? (
-          <BreadcrumbItem>
+          <BreadcrumbItem className="shrink-0">
             <BreadcrumbPage>KIWI</BreadcrumbPage>
           </BreadcrumbItem>
         ) : selectedGroup ? (
           <>
-            <BreadcrumbItem>
+            <BreadcrumbItem className="shrink-0">
               <BreadcrumbLink
+                className="max-w-full truncate"
                 href="#"
                 onClick={(e) => {
                   e.preventDefault();
@@ -41,9 +42,10 @@ export function BreadcrumbNav() {
                 KIWI
               </BreadcrumbLink>
             </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
+            <BreadcrumbSeparator className="shrink-0" />
+            <BreadcrumbItem className="min-w-0 shrink">
               <BreadcrumbLink
+                className="block max-w-full truncate"
                 href="#"
                 onClick={(e) => {
                   e.preventDefault();
@@ -55,16 +57,20 @@ export function BreadcrumbNav() {
             </BreadcrumbItem>
             {selectedProject && (
               <>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbPage>{selectedProject.name}</BreadcrumbPage>
+                <BreadcrumbSeparator className="shrink-0" />
+                <BreadcrumbItem className="min-w-0 shrink">
+                  <BreadcrumbPage className="block max-w-full truncate">
+                    {selectedProject.name}
+                  </BreadcrumbPage>
                 </BreadcrumbItem>
               </>
             )}
           </>
         ) : (
-          <BreadcrumbItem>
-            <BreadcrumbPage>{t("select.group")}</BreadcrumbPage>
+          <BreadcrumbItem className="min-w-0">
+            <BreadcrumbPage className="block max-w-full truncate">
+              {t("select.group")}
+            </BreadcrumbPage>
           </BreadcrumbItem>
         )}
       </BreadcrumbList>

--- a/frontend/components/header/BreadcrumbNav.tsx
+++ b/frontend/components/header/BreadcrumbNav.tsx
@@ -47,6 +47,7 @@ export function BreadcrumbNav() {
               <BreadcrumbLink
                 className="block max-w-full truncate"
                 href="#"
+                title={selectedGroup.name}
                 onClick={(e) => {
                   e.preventDefault();
                   selectItem(selectedGroup);
@@ -59,7 +60,10 @@ export function BreadcrumbNav() {
               <>
                 <BreadcrumbSeparator className="shrink-0" />
                 <BreadcrumbItem className="min-w-0 shrink">
-                  <BreadcrumbPage className="block max-w-full truncate">
+                  <BreadcrumbPage
+                    className="block max-w-full truncate"
+                    title={selectedProject.name}
+                  >
                     {selectedProject.name}
                   </BreadcrumbPage>
                 </BreadcrumbItem>

--- a/frontend/components/sidebar/AppSidebar.tsx
+++ b/frontend/components/sidebar/AppSidebar.tsx
@@ -14,7 +14,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Sidebar,
@@ -23,7 +22,9 @@ import {
   SidebarGroupContent,
   SidebarGroupLabel,
   SidebarHeader,
+  SidebarInput,
   SidebarMenu,
+  SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarMenuSub,
@@ -47,6 +48,7 @@ import {
   Users,
   X,
 } from "lucide-react";
+import Image from "next/image";
 import type * as React from "react";
 import { Suspense, lazy, useEffect, useMemo, useRef, useState } from "react";
 
@@ -285,12 +287,13 @@ export function AppSidebar({
             <SidebarMenuItem>
               <SidebarMenuButton size="lg" onClick={showGroups}>
                 <div className="flex aspect-square size-8 items-center justify-center rounded-lg overflow-hidden">
-                  <img
+                  <Image
                     src="/KIWI.jpg"
                     alt="KIWI"
                     width={48}
                     height={48}
-                    className="object-cover"
+                    unoptimized
+                    className="size-full object-cover"
                   />
                 </div>
                 <div className="grid flex-1 text-left text-sm leading-tight">
@@ -318,10 +321,10 @@ export function AppSidebar({
           <div className="px-2 pb-3">
             <div className="relative">
               <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground pointer-events-none" />
-              <Input
+              <SidebarInput
                 ref={searchInputRef}
                 placeholder={t("search.placeholder")}
-                className="w-full pl-9 pr-8 h-9 bg-sidebar-accent/50 border-sidebar-border focus-visible:ring-sidebar-ring"
+                className="h-9 bg-sidebar-accent/50 pl-9 pr-8 focus-visible:ring-sidebar-ring"
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
               />
@@ -529,174 +532,157 @@ function GroupItem({
 }: GroupItemProps) {
   const { selectedGroup, selectedProject, selectItem } = useNavigation();
   const { t } = useLanguage();
-  const [menuOpen, setMenuOpen] = useState(false);
   const [showCreateProject, setShowCreateProject] = useState(false);
-
-  const handleMenuClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-  };
 
   const projectsToShow = group.projects;
 
   return (
     <SidebarMenuItem>
-      <div className="relative">
-        <Collapsible
-          className="group/collapsible"
-          open={isExpanded}
-          onOpenChange={onToggleExpanded}
-        >
-          <div className="flex items-center group/header rounded-md">
-            <CollapsibleTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 p-0 hover:bg-transparent"
-                aria-label={
-                  isExpanded ? "Gruppe einklappen" : "Gruppe ausklappen"
-                }
-              >
-                <ChevronRight
-                  className={`h-4 w-4 transition-transform ${
-                    isExpanded ? "rotate-90" : ""
-                  }`}
-                />
-              </Button>
-            </CollapsibleTrigger>
-            <div className="relative flex-1">
-              <SidebarMenuButton
-                className="flex-1 pl-0"
-                isActive={selectedGroup?.id === group.id && !selectedProject}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  selectItem(group);
-                }}
-              >
-                <Users className="ml-0" />
-                <span className="truncate">
-                  {highlightTerm
-                    ? fuzzyHighlight(group.name, highlightTerm)
-                    : group.name}
-                </span>
-              </SidebarMenuButton>
-              <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
-                <DropdownMenuTrigger asChild onClick={handleMenuClick}>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 p-0 opacity-0 group-hover/header:opacity-100 transition-opacity absolute right-0 top-0"
-                  >
-                    <MoreVertical className="h-4 w-4" />
-                    <span className="sr-only">{t("options")}</span>
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  align="start"
-                  side="right"
-                  className="w-48"
-                >
-                  <DropdownMenuItem onSelect={() => onEditGroup(group)}>
-                    <Edit className="mr-2 h-4 w-4" />
-                    <span>{t("edit")}</span>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={() => setShowCreateProject(true)}>
-                    <Plus className="mr-2 h-4 w-4" />
-                    <span>{t("create.new.project")}</span>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    className="text-destructive focus:text-destructive"
-                    onSelect={() => onDeleteGroup(group)}
-                  >
-                    <Trash2 className="mr-2 h-4 w-4" />
-                    <span>{t("delete")}</span>
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-              <Suspense fallback={null}>
-                <CreateProjectDialog
-                  open={showCreateProject}
-                  onOpenChange={setShowCreateProject}
-                  groupId={group.id}
-                  onProjectCreated={onProjectCreated}
-                />
-              </Suspense>
+      <Collapsible
+        className="group/collapsible"
+        open={isExpanded}
+        onOpenChange={onToggleExpanded}
+      >
+        <div className="group/group-row relative flex min-w-0 items-center gap-1">
+          <CollapsibleTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0 p-0 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+              aria-label={
+                isExpanded ? "Gruppe einklappen" : "Gruppe ausklappen"
+              }
+            >
+              <ChevronRight
+                className={`h-4 w-4 transition-transform ${
+                  isExpanded ? "rotate-90" : ""
+                }`}
+              />
+            </Button>
+          </CollapsibleTrigger>
+          <SidebarMenuButton
+            className="min-w-0 flex-1 pr-8"
+            isActive={selectedGroup?.id === group.id && !selectedProject}
+            onClick={() => selectItem(group)}
+            tooltip={group.name}
+          >
+            <Users className="shrink-0" />
+            <div className="w-0 min-w-0 flex-1 overflow-hidden">
+              <span className="block truncate">
+                {highlightTerm
+                  ? fuzzyHighlight(group.name, highlightTerm)
+                  : group.name}
+              </span>
             </div>
-          </div>
-          <CollapsibleContent>
-            <SidebarMenuSub>
-              {projectsToShow.map((project) => {
-                const isProjectMatched = matchedProjectIds?.has(project.id);
-                const isProcessing = project.processPercentage !== undefined;
+          </SidebarMenuButton>
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              asChild
+              onClick={(event) => event.stopPropagation()}
+            >
+              <SidebarMenuAction className="opacity-0 group-hover/group-row:opacity-100 group-focus-within/group-row:opacity-100 data-[state=open]:opacity-100">
+                <MoreVertical className="h-4 w-4" />
+                <span className="sr-only">{t("options")}</span>
+              </SidebarMenuAction>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" side="right" className="w-48">
+              <DropdownMenuItem onSelect={() => onEditGroup(group)}>
+                <Edit className="mr-2 h-4 w-4" />
+                <span>{t("edit")}</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setShowCreateProject(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                <span>{t("create.new.project")}</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="text-destructive focus:text-destructive"
+                onSelect={() => onDeleteGroup(group)}
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                <span>{t("delete")}</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+        <Suspense fallback={null}>
+          <CreateProjectDialog
+            open={showCreateProject}
+            onOpenChange={setShowCreateProject}
+            groupId={group.id}
+            onProjectCreated={onProjectCreated}
+          />
+        </Suspense>
+        <CollapsibleContent>
+          <SidebarMenuSub className="mr-0 pr-0">
+            {projectsToShow.map((project) => {
+              const isProjectMatched = matchedProjectIds?.has(project.id);
+              const isProcessing = project.processPercentage !== undefined;
 
-                return (
-                  <SidebarMenuItem key={project.id}>
-                    <div className="relative flex items-center group/project rounded-md">
-                      <SidebarMenuButton
-                        className="flex-1"
-                        isActive={selectedProject?.id === project.id}
-                        disabled={project.state === "create"}
-                        onClick={() => {
-                          onSelectProject(group.id);
-                          selectItem(group, project);
-                        }}
+              return (
+                <SidebarMenuItem key={project.id}>
+                  <div className="group/project-row relative">
+                    <SidebarMenuButton
+                      className="min-w-0 pr-8"
+                      isActive={selectedProject?.id === project.id}
+                      disabled={project.state === "create"}
+                      onClick={() => {
+                        onSelectProject(group.id);
+                        selectItem(group, project);
+                      }}
+                      tooltip={project.name}
+                    >
+                      {isProcessing ? (
+                        <ProjectProgressChart project={project} />
+                      ) : (
+                        <BookOpen className="shrink-0" />
+                      )}
+                      <div className="w-0 min-w-0 flex-1 overflow-hidden">
+                        <span className="block truncate">
+                          {highlightTerm && isProjectMatched
+                            ? fuzzyHighlight(project.name, highlightTerm)
+                            : project.name}
+                        </span>
+                      </div>
+                    </SidebarMenuButton>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger
+                        asChild
+                        onClick={(event) => event.stopPropagation()}
                       >
-                        {isProcessing ? (
-                          <ProjectProgressChart project={project} />
-                        ) : (
-                          <BookOpen className="shrink-0" />
-                        )}
-                        {highlightTerm && isProjectMatched ? (
-                          <span className="truncate">
-                            {fuzzyHighlight(project.name, highlightTerm)}
-                          </span>
-                        ) : (
-                          <span className="truncate">{project.name}</span>
-                        )}
-                      </SidebarMenuButton>
-                      <DropdownMenu>
-                        <DropdownMenuTrigger
-                          asChild
-                          onClick={(e) => e.stopPropagation()}
+                        <SidebarMenuAction className="opacity-0 group-hover/project-row:opacity-100 group-focus-within/project-row:opacity-100 data-[state=open]:opacity-100">
+                          <MoreVertical className="h-4 w-4" />
+                          <span className="sr-only">{t("options")}</span>
+                        </SidebarMenuAction>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent
+                        align="start"
+                        side="right"
+                        className="w-40"
+                      >
+                        <DropdownMenuItem
+                          onSelect={() => onEditProject(project, group.id)}
                         >
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-8 w-8 p-0 opacity-0 group-hover/project:opacity-100 transition-opacity absolute right-0"
-                          >
-                            <MoreVertical className="h-4 w-4" />
-                            <span className="sr-only">{t("options")}</span>
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent
-                          align="start"
-                          side="right"
-                          className="w-40"
+                          <Edit className="mr-2 h-4 w-4" />
+                          <span>{t("edit")}</span>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          className="text-destructive focus:text-destructive"
+                          onSelect={() => {
+                            onDeleteProject(project, group.id, group.name);
+                          }}
                         >
-                          <DropdownMenuItem
-                            onSelect={() => onEditProject(project, group.id)}
-                          >
-                            <Edit className="mr-2 h-4 w-4" />
-                            <span>{t("edit")}</span>
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            className="text-destructive focus:text-destructive"
-                            onSelect={() => {
-                              onDeleteProject(project, group.id, group.name);
-                            }}
-                          >
-                            <Trash2 className="mr-2 h-4 w-4" />
-                            <span>{t("delete")}</span>
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </div>
-                  </SidebarMenuItem>
-                );
-              })}
-            </SidebarMenuSub>
-          </CollapsibleContent>
-        </Collapsible>
-      </div>
+                          <Trash2 className="mr-2 h-4 w-4" />
+                          <span>{t("delete")}</span>
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                </SidebarMenuItem>
+              );
+            })}
+          </SidebarMenuSub>
+        </CollapsibleContent>
+      </Collapsible>
     </SidebarMenuItem>
   );
 }

--- a/frontend/components/sidebar/AppSidebar.tsx
+++ b/frontend/components/sidebar/AppSidebar.tsx
@@ -564,6 +564,7 @@ function GroupItem({
             className="min-w-0 flex-1 pr-8"
             isActive={selectedGroup?.id === group.id && !selectedProject}
             onClick={() => selectItem(group)}
+            title={group.name}
             tooltip={group.name}
           >
             <Users className="shrink-0" />
@@ -629,6 +630,7 @@ function GroupItem({
                         onSelectProject(group.id);
                         selectItem(group, project);
                       }}
+                      title={project.name}
                       tooltip={project.name}
                     >
                       {isProcessing ? (

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -309,7 +309,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-background relative flex w-full flex-1 flex-col",
+        "bg-background relative flex min-w-0 w-full flex-1 flex-col",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className
       )}

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -309,7 +309,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-background relative flex min-w-0 w-full flex-1 flex-col",
+        "bg-background relative flex w-full flex-1 flex-col",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className
       )}


### PR DESCRIPTION
## Summary

Fix long project and group name overflow across the frontend so sidebar rows, cards, breadcrumbs, and chat headers keep their controls visible and their layouts stable.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Reworked sidebar row layout to truncate long group and project names without hiding action menus
- Constrained long project names in cards, breadcrumbs, and the chat header to prevent horizontal overflow
- Ignored the local `evaluation/` directory in `.gitignore`

## Related Issues

Closes #214

## Testing

- Manually verified the affected views in the running `make dev` environment
- Ran `bun run lint`
- Ran `bun run format:check`
- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [ ] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

<img width="247" height="141" alt="image" src="https://github.com/user-attachments/assets/e49a60ba-3a37-4585-85d0-d0519e5ba10d" />
