### PR TITLE
fix(frontend): stabilize user message timestamps in real-time chat

### DIFF
--- a/apps/frontend/components/chat/ProjectChat.tsx
+++ b/apps/frontend/components/chat/ProjectChat.tsx
@@ -175,10 +175,17 @@ function getMessageText(message: ChatUIMessage): string {
         .join("");
 }
 
+const fallbackTimestamps = new WeakMap<ChatUIMessage, Date>();
+
 function getMessageTimestamp(message: ChatUIMessage): Date {
     const createdAt = message.metadata?.createdAt;
     if (!createdAt) {
-        return new Date();
+        let fallback = fallbackTimestamps.get(message);
+        if (!fallback) {
+            fallback = new Date();
+            fallbackTimestamps.set(message, fallback);
+        }
+        return fallback;
     }
 
     const parsed = new Date(createdAt);


### PR DESCRIPTION
## Summary

User message timestamps displayed the current time (updating on every re-render) instead of the time the message was sent. AI messages and messages loaded on page reload were unaffected.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Added a `WeakMap<ChatUIMessage, Date>` to memoize the fallback timestamp in `getMessageTimestamp()` so it is captured once per message object instead of re-evaluated on every render.

## Related Issues

Closes #273

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [x] I have run `make generate` if SQL queries were modified (backend)
- [x] I have updated barrel exports if components were added (frontend)