### PR TITLE
fix(frontend): preserve dialogs during polling

### DIFF
--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -53,6 +53,7 @@ function DashboardContent() {
     const [headerReady, setHeaderReady] = useState(false);
     const processingGroupIdsRef = useRef<Set<string>>(new Set());
     const processingProjectIdsRef = useRef<Set<string>>(new Set());
+    const processingProjectGroupIdsRef = useRef<Map<string, string>>(new Map());
 
     useEffect(() => {
         if (!isLoading) {
@@ -64,24 +65,23 @@ function DashboardContent() {
     useEffect(() => {
         const processingGroupIds = processingGroupIdsRef.current;
         const processingProjectIds = processingProjectIdsRef.current;
+        const processingProjectGroupIds = processingProjectGroupIdsRef.current;
 
         for (const group of groups) {
-            let groupHasProcessingProject = false;
-
             for (const project of group.projects) {
                 if (isProjectProcessing(project)) {
                     processingProjectIds.add(project.id);
-                    groupHasProcessingProject = true;
+                    processingProjectGroupIds.set(project.id, group.id);
                 } else {
                     processingProjectIds.delete(project.id);
+                    processingProjectGroupIds.delete(project.id);
                 }
             }
+        }
 
-            if (groupHasProcessingProject) {
-                processingGroupIds.add(group.id);
-            } else {
-                processingGroupIds.delete(group.id);
-            }
+        processingGroupIds.clear();
+        for (const groupId of processingProjectGroupIds.values()) {
+            processingGroupIds.add(groupId);
         }
     }, [groups]);
 

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -40,10 +40,7 @@ type DeletingProjectState = {
 };
 
 function isProjectProcessing(project: Project): boolean {
-    return (
-        project.state !== "ready" ||
-        (project.processPercentage !== undefined && project.processPercentage >= 0 && project.processPercentage < 100)
-    );
+    return project.state !== "ready";
 }
 
 function DashboardContent() {

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -10,7 +10,7 @@ import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { AppProviders, useData, useLanguage, useNavigation } from "@/providers";
 import type { Group, Project } from "@/types";
-import { Suspense, lazy, useEffect, useState } from "react";
+import { Suspense, lazy, useEffect, useRef, useState } from "react";
 
 const DeleteGroupDialog = lazy(() =>
     import("@/components/groups").then((mod) => ({
@@ -39,11 +39,20 @@ type DeletingProjectState = {
     groupName: string;
 };
 
+function isProjectProcessing(project: Project): boolean {
+    return (
+        project.state !== "ready" ||
+        (project.processPercentage !== undefined && project.processPercentage >= 0 && project.processPercentage < 100)
+    );
+}
+
 function DashboardContent() {
     const { selectedGroup, selectedProject, showAllGroups, showGroups, selectItem } = useNavigation();
     const { t } = useLanguage();
     const { groups, isLoading } = useData();
     const [headerReady, setHeaderReady] = useState(false);
+    const processingGroupIdsRef = useRef<Set<string>>(new Set());
+    const processingProjectIdsRef = useRef<Set<string>>(new Set());
 
     useEffect(() => {
         if (!isLoading) {
@@ -51,16 +60,43 @@ function DashboardContent() {
         }
     }, [isLoading]);
 
-    // Redirect when selected group/project was deleted
+    // Processing graphs can be temporarily absent during polling; avoid treating that as deletion.
+    useEffect(() => {
+        const processingGroupIds = processingGroupIdsRef.current;
+        const processingProjectIds = processingProjectIdsRef.current;
+
+        for (const group of groups) {
+            let groupHasProcessingProject = false;
+
+            for (const project of group.projects) {
+                if (isProjectProcessing(project)) {
+                    processingProjectIds.add(project.id);
+                    groupHasProcessingProject = true;
+                } else {
+                    processingProjectIds.delete(project.id);
+                }
+            }
+
+            if (groupHasProcessingProject) {
+                processingGroupIds.add(group.id);
+            } else {
+                processingGroupIds.delete(group.id);
+            }
+        }
+    }, [groups]);
+
+    // Redirect when selected group/project was deleted.
     useEffect(() => {
         if (isLoading) return;
         if (selectedGroup) {
             const group = groups.find((g) => g.id === selectedGroup.id);
             if (!group) {
+                if (processingGroupIdsRef.current.has(selectedGroup.id)) return;
                 showGroups();
                 return;
             }
             if (selectedProject && !group.projects.some((p) => p.id === selectedProject.id)) {
+                if (processingProjectIdsRef.current.has(selectedProject.id)) return;
                 selectItem(group);
             }
         }
@@ -132,7 +168,7 @@ function DashboardContent() {
                 <EditProjectDialog
                     open={editProjectDialogOpen}
                     onOpenChange={setEditProjectDialogOpen}
-                    project={editingProject ? { id: editingProject.id, name: editingProject.name } : null}
+                    project={editingProject}
                     groupId={editingProject?.groupId || null}
                 />
             </Suspense>
@@ -226,7 +262,7 @@ function Dashboard() {
                 <EditProjectDialog
                     open={editProjectDialogOpen}
                     onOpenChange={setEditProjectDialogOpen}
-                    project={editingProject ? { id: editingProject.id, name: editingProject.name } : null}
+                    project={editingProject}
                     groupId={editingProject?.groupId || null}
                 />
             </Suspense>

--- a/apps/frontend/components/chat/MessageContent.tsx
+++ b/apps/frontend/components/chat/MessageContent.tsx
@@ -16,7 +16,7 @@ import ReactMarkdown from "react-markdown";
 import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
-import { TextReferenceBadge } from "./TextReferenceBadge";
+import { TextReferenceBadge, TextReferenceDialog } from "./TextReferenceBadge";
 import { ThinkingDropdown } from "./ThinkingDropdown";
 
 type MessageContentProps = {
@@ -73,6 +73,7 @@ type ThinkingItem = { kind: "reasoning"; key: string; text: string } | { kind: "
 
 export function MessageContent({ parts, projectId, isStreaming = false }: MessageContentProps) {
     const { t } = useLanguage();
+    const [activeCitationSourceId, setActiveCitationSourceId] = React.useState<string | null>(null);
 
     const { markdownContent, citations, thinkingItems } = React.useMemo(() => {
         const citationOrder: ResolvedCitationFence[] = [];
@@ -132,6 +133,15 @@ export function MessageContent({ parts, projectId, isStreaming = false }: Messag
         return new Map(citations.map((citation, index) => [citation.sourceId, index]));
     }, [citations]);
 
+    const activeCitationIndex = activeCitationSourceId ? citationIndexMap.get(activeCitationSourceId) : undefined;
+    const activeCitation = activeCitationIndex === undefined ? undefined : citations[activeCitationIndex];
+
+    React.useEffect(() => {
+        if (activeCitationSourceId && activeCitationIndex === undefined) {
+            setActiveCitationSourceId(null);
+        }
+    }, [activeCitationIndex, activeCitationSourceId]);
+
     const shouldSkipBadgeRecursion = (node: React.ReactElement): boolean => {
         const type = typeof node.type === "string" ? node.type : undefined;
         if (type === "code" || type === "pre") return true;
@@ -165,7 +175,7 @@ export function MessageContent({ parts, projectId, isStreaming = false }: Messag
                                 key={`ref-${sourceId}-${matchCounter++}`}
                                 citation={citation}
                                 index={citationIndex}
-                                projectId={projectId}
+                                onSelect={() => setActiveCitationSourceId(sourceId)}
                             />
                         );
                     } else {
@@ -356,6 +366,20 @@ export function MessageContent({ parts, projectId, isStreaming = false }: Messag
                         ))}
                     </div>
                 </div>
+            )}
+
+            {activeCitation && activeCitationIndex !== undefined && (
+                <TextReferenceDialog
+                    citation={activeCitation}
+                    index={activeCitationIndex}
+                    projectId={projectId}
+                    open
+                    onOpenChange={(open) => {
+                        if (!open) {
+                            setActiveCitationSourceId(null);
+                        }
+                    }}
+                />
             )}
         </div>
     );

--- a/apps/frontend/components/chat/TextReferenceBadge.tsx
+++ b/apps/frontend/components/chat/TextReferenceBadge.tsx
@@ -8,31 +8,54 @@ import {
     DialogDescription,
     DialogHeader,
     DialogTitle,
-    DialogTrigger,
 } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { downloadProjectFile, fetchTextUnit } from "@/lib/api/projects";
 import { useLanguage } from "@/providers/LanguageProvider";
 import type { ResolvedCitationFence } from "@kiwi/ai/citation";
 import { Copy, ExternalLink, Loader2 } from "lucide-react";
-import React, { useEffect, useState } from "react";
+import { useEffect, useEffectEvent, useState } from "react";
 
 type TextReferenceBadgeProps = {
     citation: ResolvedCitationFence;
     index: number;
-    projectId?: string;
+    onSelect: () => void;
 };
 
-export function TextReferenceBadge({ citation, index, projectId }: TextReferenceBadgeProps) {
+type TextReferenceDialogProps = {
+    citation: ResolvedCitationFence;
+    index: number;
+    projectId?: string;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+};
+
+export function TextReferenceBadge({ citation, index, onSelect }: TextReferenceBadgeProps) {
     const { t } = useLanguage();
-    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+        <Badge
+            variant="outline"
+            asChild
+            className="mx-0.5 inline-flex cursor-pointer items-center border-2 text-xs transition-colors hover:border-primary/40 hover:bg-primary/10"
+        >
+            <button type="button" title={`${t("text.reference")} ${index + 1}: ${citation.sourceId}`} onClick={onSelect}>
+                {index + 1}
+            </button>
+        </Badge>
+    );
+}
+
+export function TextReferenceDialog({ citation, index, projectId, open, onOpenChange }: TextReferenceDialogProps) {
+    const { t } = useLanguage();
+    const getUnknownErrorLabel = useEffectEvent(() => t("error.unknown"));
     const [isLoadingUnit, setIsLoadingUnit] = useState(false);
     const [isDownloading, setIsDownloading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [unitText, setUnitText] = useState<string | null>(null);
 
     useEffect(() => {
-        if (!isOpen || !projectId || unitText !== null) {
+        if (!open || !projectId) {
             return;
         }
 
@@ -41,6 +64,7 @@ export function TextReferenceBadge({ citation, index, projectId }: TextReference
         const loadUnit = async () => {
             setIsLoadingUnit(true);
             setError(null);
+            setUnitText(null);
             try {
                 const unit = await fetchTextUnit(projectId, citation.unitId);
                 if (!isCancelled) {
@@ -48,7 +72,7 @@ export function TextReferenceBadge({ citation, index, projectId }: TextReference
                 }
             } catch (err) {
                 if (!isCancelled) {
-                    setError(err instanceof Error ? err.message : t("error.unknown"));
+                    setError(err instanceof Error ? err.message : getUnknownErrorLabel());
                 }
             } finally {
                 if (!isCancelled) {
@@ -62,7 +86,7 @@ export function TextReferenceBadge({ citation, index, projectId }: TextReference
         return () => {
             isCancelled = true;
         };
-    }, [citation.unitId, isOpen, projectId, t, unitText]);
+    }, [citation.unitId, open, projectId]);
 
     const copyToClipboard = () => {
         if (unitText) {
@@ -86,16 +110,7 @@ export function TextReferenceBadge({ citation, index, projectId }: TextReference
     };
 
     return (
-        <Dialog open={isOpen} onOpenChange={setIsOpen}>
-            <DialogTrigger asChild>
-                <Badge
-                    variant="outline"
-                    className="mx-0.5 inline-flex cursor-pointer items-center border-2 text-xs transition-colors hover:border-primary/40 hover:bg-primary/10"
-                    title={`${t("text.reference")} ${index + 1}: ${citation.sourceId}`}
-                >
-                    {index + 1}
-                </Badge>
-            </DialogTrigger>
+        <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent className="max-h-[80vh] w-full max-w-6xl overflow-hidden sm:max-w-[60vw]">
                 <div className="flex h-full flex-col overflow-hidden">
                     <DialogHeader className="shrink-0">

--- a/apps/frontend/components/chat/__tests__/MessageContent.test.tsx
+++ b/apps/frontend/components/chat/__tests__/MessageContent.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { LanguageProvider } from "@/providers/LanguageProvider";
 import type { ChatUIMessage } from "@kiwi/ai/ui";
 import { MessageContent } from "../MessageContent";
@@ -49,5 +50,28 @@ describe("MessageContent", () => {
 
         expect(screen.getAllByText("1")).toHaveLength(2);
         expect(screen.getAllByRole("button", { name: /document.pdf/i })).toHaveLength(1);
+    });
+
+    test("keeps text reference dialog open across parent rerenders", async () => {
+        const parts: ChatUIMessage["parts"] = [{ type: "text", text: `Alpha ${citationFence("src-1")} Omega` }];
+        localStorage.setItem("language", "en");
+
+        const { rerender } = render(
+            <LanguageProvider>
+                <MessageContent parts={parts} projectId="graph-1" />
+            </LanguageProvider>
+        );
+
+        await userEvent.click(screen.getByRole("button", { name: "1" }));
+        expect(await screen.findByText("Alpha evidence")).toBeInTheDocument();
+
+        rerender(
+            <LanguageProvider>
+                <MessageContent parts={parts} projectId="graph-1" />
+            </LanguageProvider>
+        );
+
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+        expect(screen.getByText("Alpha evidence")).toBeInTheDocument();
     });
 });

--- a/apps/frontend/components/groups/EditGroupDialog.tsx
+++ b/apps/frontend/components/groups/EditGroupDialog.tsx
@@ -87,24 +87,26 @@ export function EditGroupDialog({ open, onOpenChange, group }: EditGroupDialogPr
     const [availableUsers, setAvailableUsers] = useState<UserSuggestion[]>([]);
     const [isSearchingUsers, setIsSearchingUsers] = useState(false);
     const [newUserRole, setNewUserRole] = useState("user");
+    const groupId = group?.id;
+    const groupName = group?.name;
 
     const loadGroupUsers = useCallback(async () => {
-        if (!group) return;
+        if (!groupId) return;
         setIsLoading(true);
         setError(null);
         try {
-            const users = await fetchGroupUsers(group.id);
+            const users = await fetchGroupUsers(groupId);
             setEditableUsers(users.map((u) => ({ user_id: u.user_id, user_name: u.user_name, role: u.role })));
         } catch (err) {
             setError(err instanceof Error ? err.message : t("error.loading.users"));
         } finally {
             setIsLoading(false);
         }
-    }, [group, t]);
+    }, [groupId, t]);
 
     useEffect(() => {
-        if (group && open) {
-            setEditedName(group.name);
+        if (groupId && groupName !== undefined && open) {
+            setEditedName(groupName);
             loadGroupUsers();
         } else {
             setError(null);
@@ -112,7 +114,7 @@ export function EditGroupDialog({ open, onOpenChange, group }: EditGroupDialogPr
             setSelectedUser(null);
             setNewUserRole("user");
         }
-    }, [group, open, loadGroupUsers]);
+    }, [groupId, groupName, open, loadGroupUsers]);
 
     const loadAvailableUsers = useCallback(async () => {
         if (!canAddUser || !open) {

--- a/apps/frontend/components/projects/CreateProjectDialog.tsx
+++ b/apps/frontend/components/projects/CreateProjectDialog.tsx
@@ -49,9 +49,10 @@ export function CreateProjectDialog({ open, onOpenChange, groupId, onProjectCrea
     const [groupError, setGroupError] = useState(false);
 
     const nameTooLong = projectName.length > MAX_NAME_LENGTH;
+    const groupIdExists = groupId ? groups.some((group) => group.id === groupId) : false;
 
     useEffect(() => {
-        if (open && groupId && groups.some((group) => group.id === groupId)) {
+        if (open && groupId && groupIdExists) {
             setSelectedGroup(groupId);
         } else if (!open) {
             setProjectName("");
@@ -64,7 +65,7 @@ export function CreateProjectDialog({ open, onOpenChange, groupId, onProjectCrea
             setTotalBytes(0);
             setUploadSpeed(0);
         }
-    }, [open, groupId, groups]);
+    }, [open, groupId, groupIdExists]);
 
     const handleGroupChange = (value: string) => {
         setSelectedGroup(value);

--- a/apps/frontend/components/projects/EditProjectDialog.tsx
+++ b/apps/frontend/components/projects/EditProjectDialog.tsx
@@ -55,6 +55,8 @@ export function EditProjectDialog({ open, onOpenChange, project }: EditProjectDi
     const [uploadSpeed, setUploadSpeed] = useState(0);
     const [editedName, setEditedName] = useState("");
     const [filesToDelete, setFilesToDelete] = useState<string[]>([]);
+    const projectId = project?.id;
+    const projectName = project?.name;
 
     const nameTooLong = editedName.length > MAX_NAME_LENGTH;
     const {
@@ -65,8 +67,8 @@ export function EditProjectDialog({ open, onOpenChange, project }: EditProjectDi
     } = useProjectFiles(project?.id ?? "", { enabled: open && !!project });
 
     useEffect(() => {
-        if (project && open) {
-            setEditedName(project.name);
+        if (projectId && projectName !== undefined && open) {
+            setEditedName(projectName);
             setFilesToDelete([]);
         } else {
             setNewFiles([]);
@@ -78,7 +80,7 @@ export function EditProjectDialog({ open, onOpenChange, project }: EditProjectDi
             setTotalBytes(0);
             setUploadSpeed(0);
         }
-    }, [project, open]);
+    }, [projectId, projectName, open]);
 
     const handleToggleFileForDeletion = (fileKey: string) => {
         setFilesToDelete((prev) =>


### PR DESCRIPTION
## Summary

Fix polling-induced frontend state resets so dialogs and text references stay open while a graph is being processed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Preserve selected processing groups/projects across polling so temporary graph absence is not treated as deletion.
- Stabilize dialog reset dependencies and keep text reference dialog state outside remounted citation badges.
- Add coverage for text reference dialogs staying open across parent rerenders.

## Related Issues

Closes #269
Closes #274

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass

Commands run:
- `bun run test -- MessageContent.test.tsx EditProjectDialog.test.tsx EditGroupDialog.test.tsx`
- `bun run lint`
- `bun run --filter @kiwi/frontend build`

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [x] I have run `make generate` if SQL queries were modified (backend)
- [x] I have updated barrel exports if components were added (frontend)

## Screenshots (if applicable)

<!-- Not applicable: behavior-only bug fix. -->