### PR TITLE
fix: avoid raw unenriched fences

### DIFF
--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -213,8 +213,6 @@ export const chatRoute = new Elysia()
                 if (citation) {
                   citationFileKeys.add(citation.fileKey);
                   text += stringifyCitationFence(citation);
-                } else {
-                  text += segment.raw;
                 }
               }
               if (text.length > 0) {
@@ -418,20 +416,15 @@ export const chatRoute = new Elysia()
 
             const emitCitationFence = async (
               modelPartId: string,
-              rawFence: string,
               citationId: string,
             ) => {
               const citation = await enrichCitation(params.id, citationId);
-              const emittedFence = citation
-                ? stringifyCitationFence(citation)
-                : rawFence;
-              appendText(modelPartId, emittedFence);
-
               if (!citation) {
                 return;
               }
 
               citationFileKeys.add(citation.fileKey);
+              appendText(modelPartId, stringifyCitationFence(citation));
             };
 
             try {
@@ -463,7 +456,6 @@ export const chatRoute = new Elysia()
 
                       await emitCitationFence(
                         part.id,
-                        segment.raw,
                         segment.citation.sourceId,
                       );
                     }
@@ -480,7 +472,6 @@ export const chatRoute = new Elysia()
 
                         await emitCitationFence(
                           part.id,
-                          segment.raw,
                           segment.citation.sourceId,
                         );
                       }


### PR DESCRIPTION
## Summary

Fix citation fence handling so unresolved citations are omitted instead of being sent as raw model fences.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Removed the fallback that appended raw citation fences when `enrichCitation` could not resolve a source.
- Applied the omission behavior to both non-streaming generation and streamed chat responses so unresolved citations are not sent to the client or persisted to the database.

## Related Issues

Closes #

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass

Ran:

- `bun test packages/ai/src/__tests__/chat.test.ts`
- `bun run lint`

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)