### PR TITLE
feat: enable pdf hybrid mode

### DIFF
--- a/apps/worker/lib/__tests__/pdf-loader.test.ts
+++ b/apps/worker/lib/__tests__/pdf-loader.test.ts
@@ -3,19 +3,20 @@ import { describe, expect, test } from "bun:test";
 import { buildPDFLoaderOptions } from "../pdf-loader";
 
 describe("buildPDFLoaderOptions", () => {
-    test("builds full OCR PDF loader options without storage", async () => {
+    test("builds hybrid PDF loader options with storage", async () => {
         const loader = {
             getText: async () => "",
             getBinary: async () => new Uint8Array([1]).buffer,
         };
         const model = {} as never;
+        const storage = { bucket: "bucket", imagePrefix: "graphs/graph-1/files/file-1/images" };
 
-        const options = buildPDFLoaderOptions(loader, model);
+        const options = buildPDFLoaderOptions(loader, model, storage);
 
         expect(options.loader).toBe(loader);
-        expect(options.mode).toBe("ocr");
+        expect(options.mode).toBe("hybrid");
         expect(options.model).toBe(model);
-        expect("storage" in options).toBe(false);
+        expect(options.storage).toBe(storage);
     });
 
     test("throws when the image model is missing", () => {
@@ -23,7 +24,10 @@ describe("buildPDFLoaderOptions", () => {
             getText: async () => "",
             getBinary: async () => new Uint8Array([1]).buffer,
         };
+        const storage = { bucket: "bucket", imagePrefix: "graphs/graph-1/files/file-1/images" };
 
-        expect(() => buildPDFLoaderOptions(loader, undefined)).toThrow("PDF full OCR requires an image-capable model");
+        expect(() => buildPDFLoaderOptions(loader, undefined, storage)).toThrow(
+            "PDF hybrid mode requires an image-capable model"
+        );
     });
 });

--- a/apps/worker/lib/pdf-loader.ts
+++ b/apps/worker/lib/pdf-loader.ts
@@ -3,19 +3,22 @@ import { PDFLoader } from "@kiwi/graph/loader/pdf";
 
 export function buildPDFLoaderOptions(
     loader: GraphBinaryLoader,
-    model?: ConstructorParameters<typeof PDFLoader>[0]["model"]
+    model: ConstructorParameters<typeof PDFLoader>[0]["model"] | undefined,
+    storage: NonNullable<ConstructorParameters<typeof PDFLoader>[0]["storage"]>
 ): {
     loader: GraphBinaryLoader;
     mode: ConstructorParameters<typeof PDFLoader>[0]["mode"];
     model: NonNullable<ConstructorParameters<typeof PDFLoader>[0]["model"]>;
+    storage: NonNullable<ConstructorParameters<typeof PDFLoader>[0]["storage"]>;
 } {
     if (!model) {
-        throw new Error("PDF full OCR requires an image-capable model");
+        throw new Error("PDF hybrid mode requires an image-capable model");
     }
 
     return {
         loader,
-        mode: "ocr",
+        mode: "hybrid",
         model,
+        storage,
     };
 }

--- a/apps/worker/workflows/process-file.ts
+++ b/apps/worker/workflows/process-file.ts
@@ -310,7 +310,12 @@ export const processFile = defineWorkflow(
 
                 switch (fileData.type) {
                     case "pdf": {
-                        loader = new PDFLoader(buildPDFLoaderOptions(s3Loader, client.image));
+                        loader = new PDFLoader(
+                            buildPDFLoaderOptions(s3Loader, client.image, {
+                                bucket: env.S3_BUCKET,
+                                imagePrefix: derivedImagePrefix,
+                            })
+                        );
                         break;
                     }
                     case "doc": {


### PR DESCRIPTION
## Summary

Switch PDF preprocessing from full OCR to hybrid extraction so large PDFs avoid rasterizing and transcribing every page up front.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Changed worker PDF loader options to use `mode: "hybrid"` instead of full OCR.
- Passed derived image storage config into PDF hybrid processing and updated the PDF loader unit test.

## Related Issues

Closes #315

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)