### PR TITLE
feat(db): optimize indexes

### DIFF
--- a/migrations/20260510231736_daffy_punisher/migration.sql
+++ b/migrations/20260510231736_daffy_punisher/migration.sql
@@ -1,0 +1,15 @@
+CREATE INDEX "account_user_provider_idx" ON "account" ("userId","providerId");--> statement-breakpoint
+CREATE INDEX "entities_graph_active_id_idx" ON "entities" ("graph_id","active","id");--> statement-breakpoint
+CREATE INDEX "files_graph_active_created_name_idx" ON "files" ("graph_id","created_at","name") WHERE "deleted" = false;--> statement-breakpoint
+CREATE INDEX "files_graph_active_id_idx" ON "files" ("graph_id","id") WHERE "deleted" = false;--> statement-breakpoint
+CREATE INDEX "files_graph_active_key_idx" ON "files" ("graph_id","file_key") WHERE "deleted" = false;--> statement-breakpoint
+CREATE INDEX "graphs_visible_root_group_name_idx" ON "graphs" ("group_id","name") WHERE "graph_id" IS NULL AND "hidden" = false;--> statement-breakpoint
+CREATE INDEX "group_users_user_group_idx" ON "group_users" ("user_id","group_id");--> statement-breakpoint
+CREATE INDEX "relationships_graph_active_id_idx" ON "relationships" ("graph_id","active","id");--> statement-breakpoint
+CREATE INDEX "relationships_graph_active_source_id_idx" ON "relationships" ("graph_id","active","source_id","id");--> statement-breakpoint
+CREATE INDEX "relationships_graph_active_target_id_idx" ON "relationships" ("graph_id","active","target_id","id");--> statement-breakpoint
+CREATE INDEX "sources_active_id_idx" ON "sources" ("active","id");--> statement-breakpoint
+CREATE INDEX "sources_entity_active_id_idx" ON "sources" ("entity_id","active","id");--> statement-breakpoint
+CREATE INDEX "sources_relationship_active_id_idx" ON "sources" ("relationship_id","active","id");--> statement-breakpoint
+CREATE INDEX "sources_text_unit_idx" ON "sources" ("text_unit_id");--> statement-breakpoint
+CREATE INDEX "text_units_file_idx" ON "text_units" ("file_id");

--- a/migrations/20260510231736_daffy_punisher/snapshot.json
+++ b/migrations/20260510231736_daffy_punisher/snapshot.json
@@ -1,0 +1,3950 @@
+{
+    "version": "8",
+    "dialect": "postgres",
+    "id": "0bb5af93-2544-40a2-833d-bb75ea95f741",
+    "prevIds": ["b1c0e0d7-bcd9-4a7d-8d90-87f0f6cd16fa"],
+    "ddl": [
+        {
+            "isRlsEnabled": true,
+            "name": "account",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": false,
+            "name": "apikey",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "session",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "user",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "verification",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "chats",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "messages",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "entities",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "files",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "graphs",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "graph_updates",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "groups",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "group_users",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "process_run_files",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "process_runs",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "process_stats",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "relationships",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "sources",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "system_prompts",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "isRlsEnabled": true,
+            "name": "text_units",
+            "entityType": "tables",
+            "schema": "public"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "account"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "userId",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "account"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "accountId",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "account"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "providerId",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "account"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "accessToken",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "account"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "refreshToken",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "account"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "accessTokenExpiresAt",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "account"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "refreshTokenExpiresAt",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "account"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "scope",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "account"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "idToken",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "account"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "password",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "account"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "createdAt",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "account"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updatedAt",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "account"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "config_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "name",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "start",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "prefix",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "key",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "reference_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "integer",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "refill_interval",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "integer",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "refill_amount",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "timestamp(6) with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "last_refill_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "boolean",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "enabled",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "boolean",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "rate_limit_enabled",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "integer",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "rate_limit_time_window",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "integer",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "rate_limit_max",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "integer",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "request_count",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "integer",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "remaining",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "timestamp(6) with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "last_request",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "timestamp(6) with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "expires_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "timestamp(6) with time zone",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "created_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "timestamp(6) with time zone",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "updated_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "permissions",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "metadata",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "apikey"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "session"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "userId",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "session"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "token",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "session"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "expiresAt",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "session"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "ipAddress",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "session"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "userAgent",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "session"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "createdAt",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "session"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updatedAt",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "session"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "impersonatedBy",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "session"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "user"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "name",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "user"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "email",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "user"
+        },
+        {
+            "type": "boolean",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "false",
+            "generated": null,
+            "identity": null,
+            "name": "emailVerified",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "user"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "image",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "user"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "role",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "user"
+        },
+        {
+            "type": "boolean",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "banned",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "user"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "banReason",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "user"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "banExpires",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "user"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "createdAt",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "user"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updatedAt",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "user"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "verification"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "identifier",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "verification"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "value",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "verification"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "expiresAt",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "verification"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "createdAt",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "verification"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updatedAt",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "verification"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "chats"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "user_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "chats"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "project_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "chats"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "title",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "chats"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "created_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "chats"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updated_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "chats"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "messages"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "chat_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "messages"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "'pending'",
+            "generated": null,
+            "identity": null,
+            "name": "status",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "messages"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "role",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "messages"
+        },
+        {
+            "type": "jsonb",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "parts",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "messages"
+        },
+        {
+            "type": "double precision",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "tokens_per_second",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "messages"
+        },
+        {
+            "type": "double precision",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "time_to_first_token",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "messages"
+        },
+        {
+            "type": "double precision",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "input_tokens",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "messages"
+        },
+        {
+            "type": "double precision",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "output_tokens",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "messages"
+        },
+        {
+            "type": "double precision",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "total_tokens",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "messages"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "created_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "messages"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updated_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "messages"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "entities"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "graph_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "entities"
+        },
+        {
+            "type": "boolean",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "false",
+            "generated": null,
+            "identity": null,
+            "name": "active",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "entities"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "name",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "entities"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "description",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "entities"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "type",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "entities"
+        },
+        {
+            "type": "vector(4096)",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "embedding",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "entities"
+        },
+        {
+            "type": "tsvector",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": {
+                "as": "setweight(to_tsvector('simple', coalesce(name, '')), 'A') || setweight(to_tsvector('simple', coalesce(description, '')), 'B')",
+                "type": "stored"
+            },
+            "identity": null,
+            "name": "search_tsv",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "entities"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "created_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "entities"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updated_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "entities"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "graph_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "name",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "type": "integer",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "file_size",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "file_type",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "mime_type",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "file_key",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "checksum",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "type": "boolean",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "false",
+            "generated": null,
+            "identity": null,
+            "name": "deleted",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "'processing'",
+            "generated": null,
+            "identity": null,
+            "name": "status",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "'pending'",
+            "generated": null,
+            "identity": null,
+            "name": "process_step",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "type": "integer",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "0",
+            "generated": null,
+            "identity": null,
+            "name": "token_count",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "metadata",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "created_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updated_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "group_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "user_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "graph_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "name",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "description",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "'ready'",
+            "generated": null,
+            "identity": null,
+            "name": "state",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "type",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "type": "boolean",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "false",
+            "generated": null,
+            "identity": null,
+            "name": "hidden",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "created_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updated_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graph_updates"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "graph_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graph_updates"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "update_type",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graph_updates"
+        },
+        {
+            "type": "json",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "update_message",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graph_updates"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "created_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graph_updates"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updated_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "graph_updates"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "groups"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "name",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "groups"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "description",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "groups"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "created_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "groups"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updated_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "groups"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "group_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "group_users"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "user_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "group_users"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "'user'",
+            "generated": null,
+            "identity": null,
+            "name": "role",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "group_users"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "created_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "group_users"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updated_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "group_users"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "process_run_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "process_run_files"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "file_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "process_run_files"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "created_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "process_run_files"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "process_runs"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "graph_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "process_runs"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "'pending'",
+            "generated": null,
+            "identity": null,
+            "name": "status",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "process_runs"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "created_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "process_runs"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "started_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "process_runs"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "completed_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "process_runs"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updated_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "process_runs"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "process_stats"
+        },
+        {
+            "type": "double precision",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "0",
+            "generated": null,
+            "identity": null,
+            "name": "total_time",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "process_stats"
+        },
+        {
+            "type": "integer",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "0",
+            "generated": null,
+            "identity": null,
+            "name": "files",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "process_stats"
+        },
+        {
+            "type": "double precision",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "0",
+            "generated": null,
+            "identity": null,
+            "name": "file_sizes",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "process_stats"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "'unknown'",
+            "generated": null,
+            "identity": null,
+            "name": "file_type",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "process_stats"
+        },
+        {
+            "type": "integer",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "0",
+            "generated": null,
+            "identity": null,
+            "name": "token_count",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "process_stats"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "type": "boolean",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "false",
+            "generated": null,
+            "identity": null,
+            "name": "active",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "source_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "target_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "graph_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "type": "double precision",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "0",
+            "generated": null,
+            "identity": null,
+            "name": "rank",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "description",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "type": "vector(4096)",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "embedding",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "type": "tsvector",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": {
+                "as": "setweight(to_tsvector('simple', coalesce(description, '')), 'A')",
+                "type": "stored"
+            },
+            "identity": null,
+            "name": "search_tsv",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "created_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updated_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "entity_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "relationship_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "text_unit_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "type": "boolean",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": "false",
+            "generated": null,
+            "identity": null,
+            "name": "active",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "description",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "type": "vector(4096)",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "embedding",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "type": "tsvector",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": null,
+            "generated": {
+                "as": "setweight(to_tsvector('simple', coalesce(description, '')), 'A')",
+                "type": "stored"
+            },
+            "identity": null,
+            "name": "search_tsv",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "created_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updated_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "system_prompts"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "graph_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "system_prompts"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "prompt",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "system_prompts"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "created_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "system_prompts"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updated_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "system_prompts"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "text_units"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "file_id",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "text_units"
+        },
+        {
+            "type": "text",
+            "typeSchema": null,
+            "notNull": true,
+            "dimensions": 0,
+            "default": null,
+            "generated": null,
+            "identity": null,
+            "name": "text",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "text_units"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "created_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "text_units"
+        },
+        {
+            "type": "timestamp with time zone",
+            "typeSchema": null,
+            "notNull": false,
+            "dimensions": 0,
+            "default": "now()",
+            "generated": null,
+            "identity": null,
+            "name": "updated_at",
+            "entityType": "columns",
+            "schema": "public",
+            "table": "text_units"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "userId",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "providerId",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "account_user_provider_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "account"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "user_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "project_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "updated_at",
+                    "isExpression": false,
+                    "asc": false,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "idx_user_chats_user_project_updated_at",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "chats"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "chat_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "created_at",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "idx_chat_messages_chat_id_id",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "messages"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "chat_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "role",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "status",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "created_at",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "idx_chat_messages_chat_role_status_id",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "messages"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "graph_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "active",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "entities_graph_active_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "entities"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "graph_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "active",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "entities_graph_active_id_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "entities"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "name",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": {
+                        "name": "gin_trgm_ops",
+                        "default": false
+                    }
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "gin",
+            "concurrently": false,
+            "name": "entities_name_trgm_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "entities"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "embedding",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": {
+                        "name": "vector_cosine_ops",
+                        "default": false
+                    }
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "diskann",
+            "concurrently": false,
+            "name": "entities_embedding_diskann_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "entities"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "graph_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "checksum",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": true,
+            "where": "\"deleted\" = false AND \"checksum\" IS NOT NULL",
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "files_graph_checksum_active_unique",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "name",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": {
+                        "name": "gin_trgm_ops",
+                        "default": false
+                    }
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "gin",
+            "concurrently": false,
+            "name": "files_name_trgm_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "graph_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "created_at",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "name",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": "\"deleted\" = false",
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "files_graph_active_created_name_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "graph_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": "\"deleted\" = false",
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "files_graph_active_id_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "graph_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "file_key",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": "\"deleted\" = false",
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "files_graph_active_key_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "group_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "type",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "graphs_group_type_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "user_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "type",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "graphs_user_type_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "graph_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "type",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "graphs_graph_type_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "group_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "name",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": "\"graph_id\" IS NULL AND \"hidden\" = false",
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "graphs_visible_root_group_name_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "user_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "group_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "group_users_user_group_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "group_users"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "file_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "process_run_files_file_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "process_run_files"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "graph_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "status",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "created_at",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "process_runs_graph_status_created_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "process_runs"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "graph_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "active",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "relationships_graph_active_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "graph_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "active",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "relationships_graph_active_id_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "graph_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "active",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "source_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "relationships_graph_active_source_id_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "graph_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "active",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "target_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "relationships_graph_active_target_id_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "description",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": {
+                        "name": "gin_trgm_ops",
+                        "default": false
+                    }
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "gin",
+            "concurrently": false,
+            "name": "relationships_description_trgm_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "embedding",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": {
+                        "name": "vector_cosine_ops",
+                        "default": false
+                    }
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "diskann",
+            "concurrently": false,
+            "name": "relationships_embedding_diskann_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "active",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "sources_active_id_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "entity_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "active",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "sources_entity_active_id_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "relationship_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "active",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                },
+                {
+                    "value": "id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "sources_relationship_active_id_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "text_unit_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "sources_text_unit_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "description",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": {
+                        "name": "gin_trgm_ops",
+                        "default": false
+                    }
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "gin",
+            "concurrently": false,
+            "name": "sources_description_trgm_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "embedding",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": {
+                        "name": "vector_cosine_ops",
+                        "default": false
+                    }
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "diskann",
+            "concurrently": false,
+            "name": "sources_embedding_diskann_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "nameExplicit": true,
+            "columns": [
+                {
+                    "value": "file_id",
+                    "isExpression": false,
+                    "asc": true,
+                    "nullsFirst": false,
+                    "opclass": null
+                }
+            ],
+            "isUnique": false,
+            "where": null,
+            "with": "",
+            "method": "btree",
+            "concurrently": false,
+            "name": "text_units_file_idx",
+            "entityType": "indexes",
+            "schema": "public",
+            "table": "text_units"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["userId"],
+            "schemaTo": "public",
+            "tableTo": "user",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "account_userId_user_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "account"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["userId"],
+            "schemaTo": "public",
+            "tableTo": "user",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "session_userId_user_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "session"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["impersonatedBy"],
+            "schemaTo": "public",
+            "tableTo": "user",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "SET NULL",
+            "name": "session_impersonatedBy_user_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "session"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["user_id"],
+            "schemaTo": "public",
+            "tableTo": "user",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "chats_user_id_user_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "chats"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["project_id"],
+            "schemaTo": "public",
+            "tableTo": "graphs",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "chats_project_id_graphs_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "chats"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["chat_id"],
+            "schemaTo": "public",
+            "tableTo": "chats",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "messages_chat_id_chats_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "messages"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["graph_id"],
+            "schemaTo": "public",
+            "tableTo": "graphs",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "entities_graph_id_graphs_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "entities"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["graph_id"],
+            "schemaTo": "public",
+            "tableTo": "graphs",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "files_graph_id_graphs_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "files"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["group_id"],
+            "schemaTo": "public",
+            "tableTo": "groups",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "graphs_group_id_groups_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["user_id"],
+            "schemaTo": "public",
+            "tableTo": "user",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "graphs_user_id_user_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["graph_id"],
+            "schemaTo": "public",
+            "tableTo": "graphs",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "graphs_graph_id_graphs_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "graphs"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["graph_id"],
+            "schemaTo": "public",
+            "tableTo": "graphs",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "graph_updates_graph_id_graphs_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "graph_updates"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["group_id"],
+            "schemaTo": "public",
+            "tableTo": "groups",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "group_users_group_id_groups_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "group_users"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["user_id"],
+            "schemaTo": "public",
+            "tableTo": "user",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "group_users_user_id_user_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "group_users"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["process_run_id"],
+            "schemaTo": "public",
+            "tableTo": "process_runs",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "process_run_files_process_run_id_process_runs_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "process_run_files"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["file_id"],
+            "schemaTo": "public",
+            "tableTo": "files",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "process_run_files_file_id_files_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "process_run_files"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["graph_id"],
+            "schemaTo": "public",
+            "tableTo": "graphs",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "process_runs_graph_id_graphs_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "process_runs"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["source_id"],
+            "schemaTo": "public",
+            "tableTo": "entities",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "relationships_source_id_entities_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["target_id"],
+            "schemaTo": "public",
+            "tableTo": "entities",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "relationships_target_id_entities_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["graph_id"],
+            "schemaTo": "public",
+            "tableTo": "graphs",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "relationships_graph_id_graphs_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "relationships"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["entity_id"],
+            "schemaTo": "public",
+            "tableTo": "entities",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "sources_entity_id_entities_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["relationship_id"],
+            "schemaTo": "public",
+            "tableTo": "relationships",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "sources_relationship_id_relationships_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["text_unit_id"],
+            "schemaTo": "public",
+            "tableTo": "text_units",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "sources_text_unit_id_text_units_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "sources"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["graph_id"],
+            "schemaTo": "public",
+            "tableTo": "graphs",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "system_prompts_graph_id_graphs_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "system_prompts"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["file_id"],
+            "schemaTo": "public",
+            "tableTo": "files",
+            "columnsTo": ["id"],
+            "onUpdate": "NO ACTION",
+            "onDelete": "CASCADE",
+            "name": "text_units_file_id_files_id_fkey",
+            "entityType": "fks",
+            "schema": "public",
+            "table": "text_units"
+        },
+        {
+            "columns": ["process_run_id", "file_id"],
+            "nameExplicit": true,
+            "name": "process_run_files_pk",
+            "entityType": "pks",
+            "schema": "public",
+            "table": "process_run_files"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "account_pkey",
+            "schema": "public",
+            "table": "account",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "apikey_pkey",
+            "schema": "public",
+            "table": "apikey",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "session_pkey",
+            "schema": "public",
+            "table": "session",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "user_pkey",
+            "schema": "public",
+            "table": "user",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "verification_pkey",
+            "schema": "public",
+            "table": "verification",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "chats_pkey",
+            "schema": "public",
+            "table": "chats",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "messages_pkey",
+            "schema": "public",
+            "table": "messages",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "entities_pkey",
+            "schema": "public",
+            "table": "entities",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "files_pkey",
+            "schema": "public",
+            "table": "files",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "graphs_pkey",
+            "schema": "public",
+            "table": "graphs",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "graph_updates_pkey",
+            "schema": "public",
+            "table": "graph_updates",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "groups_pkey",
+            "schema": "public",
+            "table": "groups",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "process_runs_pkey",
+            "schema": "public",
+            "table": "process_runs",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "process_stats_pkey",
+            "schema": "public",
+            "table": "process_stats",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "relationships_pkey",
+            "schema": "public",
+            "table": "relationships",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "sources_pkey",
+            "schema": "public",
+            "table": "sources",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "system_prompts_pkey",
+            "schema": "public",
+            "table": "system_prompts",
+            "entityType": "pks"
+        },
+        {
+            "columns": ["id"],
+            "nameExplicit": false,
+            "name": "text_units_pkey",
+            "schema": "public",
+            "table": "text_units",
+            "entityType": "pks"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["id"],
+            "nullsNotDistinct": false,
+            "name": "apikey_id_key",
+            "schema": "public",
+            "table": "apikey",
+            "entityType": "uniques"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["token"],
+            "nullsNotDistinct": false,
+            "name": "session_token_key",
+            "schema": "public",
+            "table": "session",
+            "entityType": "uniques"
+        },
+        {
+            "nameExplicit": false,
+            "columns": ["email"],
+            "nullsNotDistinct": false,
+            "name": "user_email_key",
+            "schema": "public",
+            "table": "user",
+            "entityType": "uniques"
+        },
+        {
+            "value": "jsonb_typeof(\"parts\") = 'array'",
+            "name": "chat_messages_parts_array_check",
+            "entityType": "checks",
+            "schema": "public",
+            "table": "messages"
+        },
+        {
+            "value": "(((\"group_id\" IS NOT NULL)::int + (\"user_id\" IS NOT NULL)::int + (\"graph_id\" IS NOT NULL)::int) <= 1)",
+            "name": "graphs_single_owner_check",
+            "entityType": "checks",
+            "schema": "public",
+            "table": "graphs"
+        }
+    ],
+    "renames": []
+}

--- a/packages/db/src/tables/auth.ts
+++ b/packages/db/src/tables/auth.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { boolean, integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { boolean, index, integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 import { ulid } from "ulid";
 
 export const userTable = pgTable.withRLS("user", {
@@ -40,28 +40,32 @@ export const sessionTable = pgTable.withRLS("session", {
     impersonatedBy: text("impersonatedBy").references(() => userTable.id, { onDelete: "set null" }),
 });
 
-export const accountTable = pgTable.withRLS("account", {
-    id: text("id")
-        .primaryKey()
-        .$default(() => ulid()),
-    userId: text("userId")
-        .notNull()
-        .references(() => userTable.id, { onDelete: "cascade" }),
-    accountId: text("accountId").notNull(),
-    providerId: text("providerId").notNull(),
-    accessToken: text("accessToken"),
-    refreshToken: text("refreshToken"),
-    accessTokenExpiresAt: timestamp("accessTokenExpiresAt", { withTimezone: true, mode: "date" }),
-    refreshTokenExpiresAt: timestamp("refreshTokenExpiresAt", { withTimezone: true, mode: "date" }),
-    scope: text("scope"),
-    idToken: text("idToken"),
-    password: text("password"),
-    createdAt: timestamp("createdAt", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
-    updatedAt: timestamp("updatedAt", { withTimezone: true, mode: "date" })
-        .notNull()
-        .defaultNow()
-        .$onUpdate(() => sql`NOW()`),
-});
+export const accountTable = pgTable.withRLS(
+    "account",
+    {
+        id: text("id")
+            .primaryKey()
+            .$default(() => ulid()),
+        userId: text("userId")
+            .notNull()
+            .references(() => userTable.id, { onDelete: "cascade" }),
+        accountId: text("accountId").notNull(),
+        providerId: text("providerId").notNull(),
+        accessToken: text("accessToken"),
+        refreshToken: text("refreshToken"),
+        accessTokenExpiresAt: timestamp("accessTokenExpiresAt", { withTimezone: true, mode: "date" }),
+        refreshTokenExpiresAt: timestamp("refreshTokenExpiresAt", { withTimezone: true, mode: "date" }),
+        scope: text("scope"),
+        idToken: text("idToken"),
+        password: text("password"),
+        createdAt: timestamp("createdAt", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
+        updatedAt: timestamp("updatedAt", { withTimezone: true, mode: "date" })
+            .notNull()
+            .defaultNow()
+            .$onUpdate(() => sql`NOW()`),
+    },
+    (table) => [index("account_user_provider_idx").on(table.userId, table.providerId)]
+);
 
 export const verificationTable = pgTable.withRLS("verification", {
     id: text("id")

--- a/packages/db/src/tables/graph.ts
+++ b/packages/db/src/tables/graph.ts
@@ -70,6 +70,7 @@ export const groupUserTable = pgTable.withRLS(
         {
             primaryKey: primaryKey({ name: "group_users_pk", columns: [table.groupId, table.userId] }),
         },
+        index("group_users_user_group_idx").on(table.userId, table.groupId),
     ]
 );
 
@@ -102,6 +103,9 @@ export const graphTable = pgTable.withRLS(
         index("graphs_group_type_idx").on(table.groupId, table.type),
         index("graphs_user_type_idx").on(table.userId, table.type),
         index("graphs_graph_type_idx").on(table.graphId, table.type),
+        index("graphs_visible_root_group_name_idx")
+            .on(table.groupId, table.name)
+            .where(sql`${table.graphId} IS NULL AND ${table.hidden} = false`),
     ]
 );
 
@@ -163,84 +167,129 @@ export const filesTable = pgTable.withRLS(
         uniqueIndex("files_graph_checksum_active_unique")
             .on(table.graphId, table.checksum)
             .where(sql`${table.deleted} = false AND ${table.checksum} IS NOT NULL`),
+        index("files_name_trgm_idx").using("gin", table.name.op("gin_trgm_ops")),
+        index("files_graph_active_created_name_idx")
+            .on(table.graphId, table.createdAt, table.name)
+            .where(sql`${table.deleted} = false`),
+        index("files_graph_active_id_idx")
+            .on(table.graphId, table.id)
+            .where(sql`${table.deleted} = false`),
+        index("files_graph_active_key_idx")
+            .on(table.graphId, table.key)
+            .where(sql`${table.deleted} = false`),
     ]
 );
 
-export const textUnitTable = pgTable.withRLS("text_units", {
-    id: text("id")
-        .primaryKey()
-        .$default(() => ulid()),
-    fileId: text("file_id")
-        .notNull()
-        .references(() => filesTable.id, { onDelete: "cascade" }),
-    text: text("text").notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).defaultNow(),
-    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" })
-        .defaultNow()
-        .$onUpdate(() => sql`NOW()`),
-});
+export const textUnitTable = pgTable.withRLS(
+    "text_units",
+    {
+        id: text("id")
+            .primaryKey()
+            .$default(() => ulid()),
+        fileId: text("file_id")
+            .notNull()
+            .references(() => filesTable.id, { onDelete: "cascade" }),
+        text: text("text").notNull(),
+        createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).defaultNow(),
+        updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" })
+            .defaultNow()
+            .$onUpdate(() => sql`NOW()`),
+    },
+    (table) => [index("text_units_file_idx").on(table.fileId)]
+);
 
-export const entityTable = pgTable.withRLS("entities", {
-    id: text("id")
-        .primaryKey()
-        .$default(() => ulid()),
-    graphId: text("graph_id")
-        .notNull()
-        .references(() => graphTable.id, { onDelete: "cascade" }),
-    active: boolean("active").notNull().default(false),
-    name: text("name").notNull(),
-    description: text("description").notNull(),
-    type: text("type").notNull(),
-    embedding: vector("embedding", { dimensions: 4096 }).notNull(),
-    searchTsv: tsvector("search_tsv").generatedAlwaysAs(() => weightedTsvectorGenerated(["name", "description"])),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).defaultNow(),
-    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" })
-        .defaultNow()
-        .$onUpdate(() => sql`NOW()`),
-});
+export const entityTable = pgTable.withRLS(
+    "entities",
+    {
+        id: text("id")
+            .primaryKey()
+            .$default(() => ulid()),
+        graphId: text("graph_id")
+            .notNull()
+            .references(() => graphTable.id, { onDelete: "cascade" }),
+        active: boolean("active").notNull().default(false),
+        name: text("name").notNull(),
+        description: text("description").notNull(),
+        type: text("type").notNull(),
+        embedding: vector("embedding", { dimensions: 4096 }).notNull(),
+        searchTsv: tsvector("search_tsv").generatedAlwaysAs(() => weightedTsvectorGenerated(["name", "description"])),
+        createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).defaultNow(),
+        updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" })
+            .defaultNow()
+            .$onUpdate(() => sql`NOW()`),
+    },
+    (table) => [
+        index("entities_graph_active_idx").on(table.graphId, table.active),
+        index("entities_graph_active_id_idx").on(table.graphId, table.active, table.id),
+        index("entities_name_trgm_idx").using("gin", table.name.op("gin_trgm_ops")),
+        index("entities_embedding_diskann_idx").using("diskann", table.embedding.op("vector_cosine_ops")),
+    ]
+);
 
-export const relationshipTable = pgTable.withRLS("relationships", {
-    id: text("id")
-        .primaryKey()
-        .$default(() => ulid()),
-    active: boolean("active").notNull().default(false),
-    sourceId: text("source_id")
-        .notNull()
-        .references(() => entityTable.id, { onDelete: "cascade" }),
-    targetId: text("target_id")
-        .notNull()
-        .references(() => entityTable.id, { onDelete: "cascade" }),
-    graphId: text("graph_id")
-        .notNull()
-        .references(() => graphTable.id, { onDelete: "cascade" }),
-    rank: doublePrecision("rank").notNull().default(0),
-    description: text("description").notNull(),
-    embedding: vector("embedding", { dimensions: 4096 }).notNull(),
-    searchTsv: tsvector("search_tsv").generatedAlwaysAs(() => weightedTsvectorGenerated(["description"])),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).defaultNow(),
-    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" })
-        .defaultNow()
-        .$onUpdate(() => sql`NOW()`),
-});
+export const relationshipTable = pgTable.withRLS(
+    "relationships",
+    {
+        id: text("id")
+            .primaryKey()
+            .$default(() => ulid()),
+        active: boolean("active").notNull().default(false),
+        sourceId: text("source_id")
+            .notNull()
+            .references(() => entityTable.id, { onDelete: "cascade" }),
+        targetId: text("target_id")
+            .notNull()
+            .references(() => entityTable.id, { onDelete: "cascade" }),
+        graphId: text("graph_id")
+            .notNull()
+            .references(() => graphTable.id, { onDelete: "cascade" }),
+        rank: doublePrecision("rank").notNull().default(0),
+        description: text("description").notNull(),
+        embedding: vector("embedding", { dimensions: 4096 }).notNull(),
+        searchTsv: tsvector("search_tsv").generatedAlwaysAs(() => weightedTsvectorGenerated(["description"])),
+        createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).defaultNow(),
+        updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" })
+            .defaultNow()
+            .$onUpdate(() => sql`NOW()`),
+    },
+    (table) => [
+        index("relationships_graph_active_idx").on(table.graphId, table.active),
+        index("relationships_graph_active_id_idx").on(table.graphId, table.active, table.id),
+        index("relationships_graph_active_source_id_idx").on(table.graphId, table.active, table.sourceId, table.id),
+        index("relationships_graph_active_target_id_idx").on(table.graphId, table.active, table.targetId, table.id),
+        index("relationships_description_trgm_idx").using("gin", table.description.op("gin_trgm_ops")),
+        index("relationships_embedding_diskann_idx").using("diskann", table.embedding.op("vector_cosine_ops")),
+    ]
+);
 
-export const sourcesTable = pgTable.withRLS("sources", {
-    id: text("id")
-        .primaryKey()
-        .$default(() => ulid()),
-    entityId: text("entity_id").references(() => entityTable.id, { onDelete: "cascade" }),
-    relationshipId: text("relationship_id").references(() => relationshipTable.id, { onDelete: "cascade" }),
-    textUnitId: text("text_unit_id")
-        .notNull()
-        .references(() => textUnitTable.id, { onDelete: "cascade" }),
-    active: boolean("active").notNull().default(false),
-    description: text("description").notNull(),
-    embedding: vector("embedding", { dimensions: 4096 }).notNull(),
-    searchTsv: tsvector("search_tsv").generatedAlwaysAs(() => weightedTsvectorGenerated(["description"])),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).defaultNow(),
-    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" })
-        .defaultNow()
-        .$onUpdate(() => sql`NOW()`),
-});
+export const sourcesTable = pgTable.withRLS(
+    "sources",
+    {
+        id: text("id")
+            .primaryKey()
+            .$default(() => ulid()),
+        entityId: text("entity_id").references(() => entityTable.id, { onDelete: "cascade" }),
+        relationshipId: text("relationship_id").references(() => relationshipTable.id, { onDelete: "cascade" }),
+        textUnitId: text("text_unit_id")
+            .notNull()
+            .references(() => textUnitTable.id, { onDelete: "cascade" }),
+        active: boolean("active").notNull().default(false),
+        description: text("description").notNull(),
+        embedding: vector("embedding", { dimensions: 4096 }).notNull(),
+        searchTsv: tsvector("search_tsv").generatedAlwaysAs(() => weightedTsvectorGenerated(["description"])),
+        createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).defaultNow(),
+        updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" })
+            .defaultNow()
+            .$onUpdate(() => sql`NOW()`),
+    },
+    (table) => [
+        index("sources_active_id_idx").on(table.active, table.id),
+        index("sources_entity_active_id_idx").on(table.entityId, table.active, table.id),
+        index("sources_relationship_active_id_idx").on(table.relationshipId, table.active, table.id),
+        index("sources_text_unit_idx").on(table.textUnitId),
+        index("sources_description_trgm_idx").using("gin", table.description.op("gin_trgm_ops")),
+        index("sources_embedding_diskann_idx").using("diskann", table.embedding.op("vector_cosine_ops")),
+    ]
+);
 
 export const processStatsTable = pgTable.withRLS("process_stats", {
     id: text("id")


### PR DESCRIPTION
## Summary

Add query-driven database indexes and bring manually added migration indexes back into the Drizzle table definitions so generated snapshots match the actual database schema.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Added TypeScript schema definitions for previously manual indexes, including trigram, DiskANN vector, graph/active, file name, and checksum indexes.
- Added new indexes for frequently used query paths around files, graph listing, group membership, account lookup, text units, sources, entities, and relationships.
- Generated a new Drizzle migration and removed SQL statements for indexes/columns already applied by older manual migrations while keeping the snapshot aligned.

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)