### PR TITLE
fix(worker): image extraction in pfd

### DIFF
--- a/apps/worker/workflows/process-file.ts
+++ b/apps/worker/workflows/process-file.ts
@@ -106,7 +106,7 @@ export const processFiles = defineWorkflow(processFilesSpec, async ({ input, ste
             }
         });
 
-        await Promise.allSettled(
+        const fileResults = await Promise.allSettled(
             input.fileIds.map((fileId) =>
                 step.runWorkflow(processFile.spec, {
                     graphId: input.graphId,
@@ -114,6 +114,9 @@ export const processFiles = defineWorkflow(processFilesSpec, async ({ input, ste
                 })
             )
         );
+        if (fileResults.length > 0 && fileResults.every((result) => result.status === "rejected")) {
+            throw new Error(`All ${fileResults.length} file processing workflows failed`);
+        }
 
         const descriptions = await step.run({ name: "generate-descriptions" }, async () => {
             const newEntities = await db

--- a/packages/ai/src/prompts/image.prompt.ts
+++ b/packages/ai/src/prompts/image.prompt.ts
@@ -45,6 +45,8 @@ You analyze images embedded inside documents and presentations.
 # Instructions
 - Describe the embedded visual accurately and concisely.
 - Preserve all visible text exactly as written.
+- If the image is a small logo or brand mark, return "LOGO: <one sentence>" with only the essential identity and visible text.
+- If the image is a small icon, pictogram, or UI glyph, return "ICON: <one short sentence>" with only the essential meaning or shape.
 - Cover charts, diagrams, figures, screenshots, stamps, scanned inserts, and other non-text visuals.
 - Include labels, annotations, axes, legends, symbols, and notable structure when present.
 - Do not invent missing details.

--- a/packages/graph/src/lib/__tests__/ocr-image.test.ts
+++ b/packages/graph/src/lib/__tests__/ocr-image.test.ts
@@ -45,6 +45,50 @@ describe("processOCRImages", () => {
         });
     });
 
+    test("processes images in configured image concurrency batches", async () => {
+        const previousConcurrency = process.env.AI_IMAGE_CONCURRENCY;
+        process.env.AI_IMAGE_CONCURRENCY = "2";
+        let active = 0;
+        let maxActive = 0;
+        const describeImage = mock(async (image: { id: string }) => {
+            active += 1;
+            maxActive = Math.max(maxActive, active);
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            active -= 1;
+            return image.id;
+        });
+        const uploadImage = mock(async (name: string, _content: Uint8Array, storage: { imagePrefix: string }) => ({
+            key: `${storage.imagePrefix}/${name}`,
+        }));
+
+        const images = Array.from({ length: 5 }, (_, index) => ({
+            id: `img-${index + 1}`,
+            type: "image/png",
+            content: new Uint8Array([index]),
+        }));
+        const text = images.map((image) => `:::IMG-${image.id}:::`).join("\n");
+
+        try {
+            await processOCRImages(
+                text,
+                images,
+                {} as never,
+                { bucket: "bucket", imagePrefix: "graphs/g-1/derived/f-1/images" },
+                { describeImage, uploadImage }
+            );
+
+            expect(maxActive).toBe(2);
+            expect(describeImage).toHaveBeenCalledTimes(5);
+            expect(uploadImage).toHaveBeenCalledTimes(5);
+        } finally {
+            if (previousConcurrency === undefined) {
+                delete process.env.AI_IMAGE_CONCURRENCY;
+            } else {
+                process.env.AI_IMAGE_CONCURRENCY = previousConcurrency;
+            }
+        }
+    });
+
     test("maps supported mime types to deterministic extensions", () => {
         expect(getExtensionForMimeType("image/png")).toBe("png");
         expect(getExtensionForMimeType("image/jpeg")).toBe("jpg");

--- a/packages/graph/src/lib/ocr-image.ts
+++ b/packages/graph/src/lib/ocr-image.ts
@@ -21,6 +21,7 @@ type OCRImageDeps = {
 };
 
 const IMAGE_FENCE_PATTERN = /:::IMG-[^:]+:::/;
+const DEFAULT_IMAGE_BATCH_SIZE = 64;
 
 export async function processOCRImages(
     text: string,
@@ -54,18 +55,25 @@ export async function processOCRImages(
         }
     }
 
-    const replacements = await Promise.all(
-        images.map(async (image) => {
-            const description = (await describeImage(image, model)).trim();
-            const extension = getExtensionForMimeType(image.type);
-            const uploaded = await uploadImage(`${image.id}.${extension}`, image.content, storage);
+    const replacements: Array<{ fence: string; tag: string }> = [];
+    const batchSize = getImageBatchSize();
+    for (let index = 0; index < images.length; index += batchSize) {
+        const batch = images.slice(index, index + batchSize);
+        replacements.push(
+            ...(await Promise.all(
+                batch.map(async (image) => {
+                    const description = (await describeImage(image, model)).trim();
+                    const extension = getExtensionForMimeType(image.type);
+                    const uploaded = await uploadImage(`${image.id}.${extension}`, image.content, storage);
 
-            return {
-                fence: `:::IMG-${image.id}:::`,
-                tag: renderImageTag(image.id, uploaded.key, description),
-            };
-        })
-    );
+                    return {
+                        fence: `:::IMG-${image.id}:::`,
+                        tag: renderImageTag(image.id, uploaded.key, description),
+                    };
+                })
+            ))
+        );
+    }
 
     let output = text;
     for (const replacement of replacements) {
@@ -78,6 +86,11 @@ export async function processOCRImages(
     }
 
     return output;
+}
+
+function getImageBatchSize(): number {
+    const value = Number(process.env.AI_IMAGE_CONCURRENCY);
+    return !Number.isFinite(value) || value < 1 ? DEFAULT_IMAGE_BATCH_SIZE : Math.floor(value);
 }
 
 async function defaultDescribeImage(image: OCRImageAsset, model: LanguageModelV3): Promise<string> {

--- a/packages/graph/src/loader/__tests__/pdf.test.ts
+++ b/packages/graph/src/loader/__tests__/pdf.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { PDF, degrees, measureText, rgb } from "@libpdf/core";
 import { transcribePrompt } from "@kiwi/ai/prompts/transcribe.prompt";
+import { inflateSync } from "node:zlib";
 
 let fullOCRPageOutputs: string[] = [];
 let rasterizedPages: Uint8Array[] = [];
@@ -52,6 +53,8 @@ mock.module("pdf-to-img", () => ({
 const { PDFLoader } = await import("../pdf.ts");
 
 const PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO6rmS0AAAAASUVORK5CYII=";
+const AWIFOE_RAW_IMAGE_BASE64 = "eJztwTEBAAAAwqD1T20Hb6AAAAAAAAAAAAAAAAAAAAB+Azy0AAE=";
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 
 function drawPositionedTable(
     page: ReturnType<PDF["addPage"]>,
@@ -175,6 +178,10 @@ function encodeUtf16BEHex(value: string): string {
         .toUpperCase();
 }
 
+function isPNG(bytes: Uint8Array): boolean {
+    return PNG_SIGNATURE.every((byte, index) => bytes[index] === byte);
+}
+
 async function buildLineTableFixture() {
     return buildHybridFixture(async (pdf) => {
         const pngBytes = Uint8Array.from(Buffer.from(PNG_BASE64, "base64"));
@@ -208,6 +215,131 @@ async function buildLineTableFixture() {
             ["Bar", "84"],
         ]);
     });
+}
+
+function buildRawFlateImagePDF(): Uint8Array {
+    const rawImage = Buffer.from(AWIFOE_RAW_IMAGE_BASE64, "base64");
+    const content = Buffer.from(
+        [
+            "BT /F1 18 Tf 50 700 Td (Raw PDF Image) Tj ET",
+            "q",
+            "140 0 0 37 50 600 cm",
+            "/ImRaw Do",
+            "Q",
+        ].join("\n"),
+        "latin1"
+    );
+    const objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 800] /Resources << /Font << /F1 6 0 R >> /XObject << /ImRaw 5 0 R >> >> /Contents 4 0 R >>",
+        pdfStream(`<< /Length ${content.length} >>`, content),
+        pdfStream(
+            "<< /Type /XObject /Subtype /Image /Width 140 /Height 37 /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /FlateDecode /Length 38 >>",
+            rawImage
+        ),
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ];
+
+    return buildPDF(objects);
+}
+
+function buildRawCMYKImagePDF(): Uint8Array {
+    const rawImage = Buffer.from([0x78, 0x9c, 0x6b, 0x68, 0x68, 0x68, 0x00, 0x00, 0x03, 0x05, 0x02, 0x01]);
+    const content = Buffer.from(["q", "1 0 0 1 50 600 cm", "/ImRaw Do", "Q"].join("\n"), "latin1");
+    const objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources << /XObject << /ImRaw 5 0 R >> >> /Contents 4 0 R >>",
+        pdfStream(`<< /Length ${content.length} >>`, content),
+        pdfStream(
+            `<< /Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceCMYK /BitsPerComponent 8 /Filter /FlateDecode /Length ${rawImage.length} >>`,
+            rawImage
+        ),
+        "<< >>",
+    ];
+
+    return buildPDF(objects);
+}
+
+function buildAsciiHexJPEGImagePDF(): Uint8Array {
+    const jpegHex = Buffer.from("FFD8FFE000104A46494600010100000100010000FFDB>", "latin1");
+    const content = Buffer.from(["q", "1 0 0 1 50 600 cm", "/ImRaw Do", "Q"].join("\n"), "latin1");
+    const objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources << /XObject << /ImRaw 5 0 R >> >> /Contents 4 0 R >>",
+        pdfStream(`<< /Length ${content.length} >>`, content),
+        pdfStream(
+            `<< /Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter [/ASCIIHexDecode /DCTDecode] /Length ${jpegHex.length} >>`,
+            jpegHex
+        ),
+        "<< >>",
+    ];
+
+    return buildPDF(objects);
+}
+
+function readFirstPNGPixel(png: Uint8Array): [number, number, number] {
+    const chunks = readPNGChunks(png);
+    const idat = Buffer.concat(chunks.filter((chunk) => chunk.type === "IDAT").map((chunk) => Buffer.from(chunk.data)));
+    const scanline = inflateSync(idat);
+
+    return [scanline[1]!, scanline[2]!, scanline[3]!];
+}
+
+function isJPEG(bytes: Uint8Array): boolean {
+    return bytes[0] === 0xff && bytes[1] === 0xd8;
+}
+
+function readPNGChunks(png: Uint8Array): Array<{ type: string; data: Uint8Array }> {
+    const chunks: Array<{ type: string; data: Uint8Array }> = [];
+    let offset = 8;
+
+    while (offset + 8 <= png.length) {
+        const length = new DataView(png.buffer, png.byteOffset + offset, 4).getUint32(0);
+        const type = Buffer.from(png.subarray(offset + 4, offset + 8)).toString("latin1");
+        const data = png.subarray(offset + 8, offset + 8 + length);
+        chunks.push({ type, data });
+        offset += 12 + length;
+    }
+
+    return chunks;
+}
+
+function pdfStream(dictionary: string, content: Buffer): Buffer {
+    return Buffer.concat([Buffer.from(`${dictionary}\nstream\n`, "latin1"), content, Buffer.from("\nendstream", "latin1")]);
+}
+
+function buildPDF(objects: Array<string | Buffer>): Uint8Array {
+    const chunks: Buffer[] = [Buffer.from("%PDF-1.4\n", "latin1")];
+    const offsets = [0];
+    let length = chunks[0]!.length;
+
+    objects.forEach((object, index) => {
+        const objectHeader = Buffer.from(`${index + 1} 0 obj\n`, "latin1");
+        const objectBody = typeof object === "string" ? Buffer.from(object, "latin1") : object;
+        const objectFooter = Buffer.from("\nendobj\n", "latin1");
+
+        offsets.push(length);
+        chunks.push(objectHeader, objectBody, objectFooter);
+        length += objectHeader.length + objectBody.length + objectFooter.length;
+    });
+
+    const xrefOffset = length;
+    chunks.push(Buffer.from(`xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`, "latin1"));
+    for (const offset of offsets.slice(1)) {
+        chunks.push(Buffer.from(`${offset.toString().padStart(10, "0")} 00000 n \n`, "latin1"));
+    }
+
+    chunks.push(
+        Buffer.from(
+            `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`,
+            "latin1"
+        )
+    );
+
+    return Uint8Array.from(Buffer.concat(chunks));
 }
 
 async function buildAlignedTextTableFixture() {
@@ -586,7 +718,36 @@ describe("PDFLoader", () => {
         expect(fixture.hybrid).toMatch(/\| Bar \| 84 \|/);
         expect(generateTextMock).toHaveBeenCalledTimes(1);
         expect(putNamedFileMock).toHaveBeenCalledTimes(1);
+        expect(isPNG(putNamedFileMock.mock.calls[0]?.[1] as Uint8Array)).toBe(true);
         expect(pdfToImgMock).not.toHaveBeenCalled();
+    });
+
+    test("converts a raw FlateDecode image stream from the AWiFoe PDF into a PNG", async () => {
+        const fixture = await buildHybridFixtureFromBytes(buildRawFlateImagePDF());
+
+        expect(fixture.hybrid).toMatch(/^Raw PDF Image$/m);
+        expect(fixture.hybrid).toContain(
+            '<image id="img-1" key="graphs/graph-1/derived/file-1/images/img-1.png">PDF figure summary</image>'
+        );
+        expect(generateTextMock).toHaveBeenCalledTimes(1);
+        expect(putNamedFileMock).toHaveBeenCalledTimes(1);
+        expect(isPNG(Buffer.from(AWIFOE_RAW_IMAGE_BASE64, "base64"))).toBe(false);
+        expect(isPNG(putNamedFileMock.mock.calls[0]?.[1] as Uint8Array)).toBe(true);
+    });
+
+    test("converts raw CMYK image samples to RGB without additive black clipping", async () => {
+        await buildHybridFixtureFromBytes(buildRawCMYKImagePDF());
+
+        expect(putNamedFileMock).toHaveBeenCalledTimes(1);
+        expect(readFirstPNGPixel(putNamedFileMock.mock.calls[0]?.[1] as Uint8Array)).toEqual([63, 63, 63]);
+    });
+
+    test("decodes filters before DCTDecode instead of uploading encoded wrapper bytes", async () => {
+        await buildHybridFixtureFromBytes(buildAsciiHexJPEGImagePDF());
+
+        expect(putNamedFileMock).toHaveBeenCalledTimes(1);
+        expect(putNamedFileMock.mock.calls[0]?.[0]).toBe("img-1.jpg");
+        expect(isJPEG(putNamedFileMock.mock.calls[0]?.[1] as Uint8Array)).toBe(true);
     });
 
     test("detects aligned text tables as markdown in hybrid mode", async () => {

--- a/packages/graph/src/loader/pdf.ts
+++ b/packages/graph/src/loader/pdf.ts
@@ -3,6 +3,7 @@ import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { withAiSlot } from "@kiwi/ai/lock";
 import { transcribePrompt } from "@kiwi/ai/prompts/transcribe.prompt";
 import { generateText } from "ai";
+import { deflateSync } from "node:zlib";
 import { pdf } from "pdf-to-img";
 import type { GraphBinaryLoader, GraphLoader } from "..";
 import { processOCRImages } from "../lib/ocr-image";
@@ -114,6 +115,11 @@ type PDFStreamLike = PDFDictLike & {
     type: "stream";
     data: Uint8Array;
     getDecodedData: () => Uint8Array;
+};
+
+type PDFImageAsset = {
+    type: string;
+    content: Uint8Array;
 };
 
 type PDFPageLike = {
@@ -377,6 +383,8 @@ const A4_WIDTH_POINTS = 595.28;
 const A4_HEIGHT_POINTS = 841.89;
 const A4_OVERSIZE_TOLERANCE = 1.1;
 const PNG_MIME_TYPE = "image/png";
+const JPEG_MIME_TYPE = "image/jpeg";
+const PNG_SIGNATURE = Uint8Array.of(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a);
 const LIGATURE_EXPANSIONS: Record<string, string> = {
     ﬀ: "ff",
     ﬃ: "ffi",
@@ -2639,11 +2647,12 @@ function handlePaintedObject(options: {
 
     const subtype = raw.getName("Subtype", resolver)?.value;
     if (subtype === "Image") {
+        const asset = extractPDFImageAsset(raw, resolver);
         const bbox = transformUnitSquare(ctm);
         occurrences.push({
             id: nextImageId(),
-            type: getImageMimeType(raw, resolver),
-            content: safelyDecodeStream(raw),
+            type: asset.type,
+            content: asset.content,
             bbox,
             pageIndex,
         });
@@ -3297,37 +3306,232 @@ function isPDFNumber(value: unknown): value is PDFNumberLike {
     return typeof value === "object" && value !== null && (value as { type?: string }).type === "number";
 }
 
-function getImageMimeType(stream: PDFStreamLike, resolver?: (ref: PDFRefLike) => unknown): string {
-    const filter = stream.get("Filter", resolver);
-    const filterNames = getPDFFilterNames(filter, resolver);
+function extractPDFImageAsset(stream: PDFStreamLike, resolver?: (ref: PDFRefLike) => unknown): PDFImageAsset {
+    const filterNames = getPDFFilterNames(stream.get("Filter", resolver), resolver);
 
-    if (filterNames.includes("DCTDecode") || filterNames.includes("JPXDecode")) {
-        return "image/jpeg";
+    if (filterNames[0] === "DCTDecode") {
+        return { type: JPEG_MIME_TYPE, content: stream.data };
     }
 
-    if (filterNames.includes("FlateDecode")) {
-        return "image/png";
+    const decoded = safelyDecodeStream(stream);
+    const detectedType = detectEncodedImageMimeType(decoded);
+    if (detectedType) {
+        return { type: detectedType, content: decoded };
     }
 
-    const bytes = safelyDecodeStream(stream);
+    const encodedType = detectEncodedImageMimeType(stream.data);
+    if (encodedType) {
+        return { type: encodedType, content: stream.data };
+    }
+
+    const png = encodeDecodedPDFImageAsPNG(stream, decoded, resolver);
+    return { type: PNG_MIME_TYPE, content: png };
+}
+
+function detectEncodedImageMimeType(bytes: Uint8Array): string | null {
     if (bytes[0] === 0xff && bytes[1] === 0xd8) {
-        return "image/jpeg";
+        return JPEG_MIME_TYPE;
+    }
+
+    if (startsWithBytes(bytes, PNG_SIGNATURE)) {
+        return PNG_MIME_TYPE;
+    }
+
+    if (bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x38) {
+        return "image/gif";
     }
 
     if (
-        bytes[0] === 0x89 &&
-        bytes[1] === 0x50 &&
-        bytes[2] === 0x4e &&
-        bytes[3] === 0x47 &&
-        bytes[4] === 0x0d &&
-        bytes[5] === 0x0a &&
-        bytes[6] === 0x1a &&
-        bytes[7] === 0x0a
+        bytes[0] === 0x52 &&
+        bytes[1] === 0x49 &&
+        bytes[2] === 0x46 &&
+        bytes[3] === 0x46 &&
+        bytes[8] === 0x57 &&
+        bytes[9] === 0x45 &&
+        bytes[10] === 0x42 &&
+        bytes[11] === 0x50
     ) {
-        return "image/png";
+        return "image/webp";
     }
 
-    return "image/png";
+    return null;
+}
+
+function encodeDecodedPDFImageAsPNG(
+    stream: PDFStreamLike,
+    decoded: Uint8Array,
+    resolver?: (ref: PDFRefLike) => unknown
+): Uint8Array {
+    const width = stream.getNumber("Width", resolver)?.value;
+    const height = stream.getNumber("Height", resolver)?.value;
+    const bitsPerComponent = stream.getNumber("BitsPerComponent", resolver)?.value ?? 8;
+
+    if (
+        typeof width !== "number" ||
+        typeof height !== "number" ||
+        !Number.isInteger(width) ||
+        !Number.isInteger(height) ||
+        width <= 0 ||
+        height <= 0
+    ) {
+        return decoded;
+    }
+
+    const colorSpace = getColorSpaceName(stream.get("ColorSpace", resolver), resolver);
+    const rgb = decodedPDFImageToRGB(decoded, width, height, bitsPerComponent, colorSpace, isImageMask(stream, resolver));
+    if (!rgb) {
+        return decoded;
+    }
+
+    return encodeRGBPNG(width, height, rgb);
+}
+
+function decodedPDFImageToRGB(
+    decoded: Uint8Array,
+    width: number,
+    height: number,
+    bitsPerComponent: number,
+    colorSpace: string | null,
+    imageMask: boolean
+): Uint8Array | null {
+    const pixelCount = width * height;
+
+    if (imageMask || bitsPerComponent === 1) {
+        const output = new Uint8Array(pixelCount * 3);
+        for (let index = 0; index < pixelCount; index += 1) {
+            const byte = decoded[index >> 3] ?? 0;
+            const bit = (byte >> (7 - (index % 8))) & 1;
+            const value = imageMask ? (bit === 1 ? 0 : 255) : bit * 255;
+            output[index * 3] = value;
+            output[index * 3 + 1] = value;
+            output[index * 3 + 2] = value;
+        }
+        return output;
+    }
+
+    if (bitsPerComponent !== 8) {
+        return null;
+    }
+
+    if (colorSpace === "DeviceGray" || decoded.length === pixelCount) {
+        const output = new Uint8Array(pixelCount * 3);
+        for (let index = 0; index < pixelCount; index += 1) {
+            const value = decoded[index] ?? 0;
+            output[index * 3] = value;
+            output[index * 3 + 1] = value;
+            output[index * 3 + 2] = value;
+        }
+        return output;
+    }
+
+    if (colorSpace === "DeviceCMYK" || decoded.length >= pixelCount * 4) {
+        const output = new Uint8Array(pixelCount * 3);
+        for (let index = 0; index < pixelCount; index += 1) {
+            const source = index * 4;
+            const c = decoded[source] ?? 0;
+            const m = decoded[source + 1] ?? 0;
+            const y = decoded[source + 2] ?? 0;
+            const k = decoded[source + 3] ?? 0;
+            output[index * 3] = Math.round(((255 - c) * (255 - k)) / 255);
+            output[index * 3 + 1] = Math.round(((255 - m) * (255 - k)) / 255);
+            output[index * 3 + 2] = Math.round(((255 - y) * (255 - k)) / 255);
+        }
+        return output;
+    }
+
+    if (colorSpace === "DeviceRGB" || decoded.length >= pixelCount * 3) {
+        return decoded.slice(0, pixelCount * 3);
+    }
+
+    return null;
+}
+
+function getColorSpaceName(value: unknown, resolver?: (ref: PDFRefLike) => unknown): string | null {
+    if (isPDFName(value)) {
+        return value.value;
+    }
+
+    if (!isPDFArray(value)) {
+        return null;
+    }
+
+    const first = value.at(0, resolver);
+    return isPDFName(first) ? first.value : null;
+}
+
+function isImageMask(stream: PDFStreamLike, resolver?: (ref: PDFRefLike) => unknown): boolean {
+    const value = stream.get("ImageMask", resolver);
+    return value === true || value === "true";
+}
+
+function encodeRGBPNG(width: number, height: number, rgb: Uint8Array): Uint8Array {
+    const stride = width * 3;
+    const scanlines = new Uint8Array((stride + 1) * height);
+    for (let y = 0; y < height; y += 1) {
+        const targetOffset = y * (stride + 1);
+        const sourceOffset = y * stride;
+        scanlines[targetOffset] = 0;
+        scanlines.set(rgb.subarray(sourceOffset, sourceOffset + stride), targetOffset + 1);
+    }
+
+    return joinBytes([
+        PNG_SIGNATURE,
+        createPNGChunk("IHDR", createPNGHeader(width, height)),
+        createPNGChunk("IDAT", deflateSync(scanlines)),
+        createPNGChunk("IEND", new Uint8Array()),
+    ]);
+}
+
+function createPNGHeader(width: number, height: number): Uint8Array {
+    const header = new Uint8Array(13);
+    const view = new DataView(header.buffer);
+    view.setUint32(0, width);
+    view.setUint32(4, height);
+    header[8] = 8;
+    header[9] = 2;
+    return header;
+}
+
+function createPNGChunk(type: string, data: Uint8Array): Uint8Array {
+    const typeBytes = new TextEncoder().encode(type);
+    const chunk = new Uint8Array(4 + typeBytes.length + data.length + 4);
+    const view = new DataView(chunk.buffer);
+    view.setUint32(0, data.length);
+    chunk.set(typeBytes, 4);
+    chunk.set(data, 8);
+    view.setUint32(8 + data.length, crc32(chunk.subarray(4, 8 + data.length)));
+    return chunk;
+}
+
+function joinBytes(chunks: Uint8Array[]): Uint8Array {
+    const length = chunks.reduce((total, chunk) => total + chunk.length, 0);
+    const output = new Uint8Array(length);
+    let offset = 0;
+    for (const chunk of chunks) {
+        output.set(chunk, offset);
+        offset += chunk.length;
+    }
+    return output;
+}
+
+function startsWithBytes(bytes: Uint8Array, prefix: Uint8Array): boolean {
+    if (bytes.length < prefix.length) {
+        return false;
+    }
+
+    return prefix.every((byte, index) => bytes[index] === byte);
+}
+
+function crc32(bytes: Uint8Array): number {
+    let crc = 0xffffffff;
+    for (const byte of bytes) {
+        crc ^= byte;
+        for (let bit = 0; bit < 8; bit += 1) {
+            crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+        }
+    }
+
+    return (crc ^ 0xffffffff) >>> 0;
 }
 
 function getPDFFilterNames(value: unknown, resolver?: (ref: PDFRefLike) => unknown): string[] {


### PR DESCRIPTION
## Summary

Fixes hybrid PDF image extraction so raw embedded PDF image streams are converted into valid image files before OCR/upload, and ensures parent file-processing workflows fail when every child file workflow fails.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Convert raw PDF image XObject data into valid PNG bytes for hybrid extraction, while preserving already-encoded JPEG/PNG/GIF/WebP images.
- Batch embedded image OCR work by `AI_IMAGE_CONCURRENCY` with a fallback of `64`.
- Add regression coverage for raw `FlateDecode` PDF image conversion and image OCR batching.
- Update embedded image prompt behavior for small logos/icons.
- Fail the parent `process-files` workflow when all child `process-file` workflows fail.

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass

Validated with:

- `bun test packages/graph/src/loader/__tests__/pdf.test.ts packages/graph/src/lib/__tests__/ocr-image.test.ts`
- `bun run --filter @kiwi/graph build`
- `bun run --filter @kiwi/ai build`
- `bun run --filter @kiwi/worker build`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)
