### PR TITLE
bug(backend): cancle active workflows upon deletion

### DIFF
--- a/apps/api/src/lib/workflow-cancellation.ts
+++ b/apps/api/src/lib/workflow-cancellation.ts
@@ -1,0 +1,169 @@
+import { db } from "@kiwi/db";
+import { error as logError } from "@kiwi/logger";
+import { sql } from "drizzle-orm";
+import { ow } from "../openworkflow";
+
+type WorkflowRunIdRow = {
+    id: string;
+};
+
+type CancellationContext = {
+    graphIds: string[];
+    fileIds?: string[];
+    workflowNames?: string[];
+};
+
+export type WorkflowCancellationSummary = {
+    requestedCount: number;
+    canceledCount: number;
+    skippedCount: number;
+};
+
+const OPENWORKFLOW_NAMESPACE_ID = "default";
+const ACTIVE_WORKFLOW_STATUSES = ["pending", "running", "sleeping"] as const;
+const MAX_CANCELLATION_PASSES = 5;
+
+function textList(values: readonly string[]) {
+    return sql.join(
+        values.map((value) => sql`${value}`),
+        sql`, `
+    );
+}
+
+function isAlreadyTerminalCancelError(error: unknown) {
+    if (!(error instanceof Error)) {
+        return false;
+    }
+
+    return (
+        error.message.includes("does not exist") ||
+        (error.message.includes("Cannot cancel workflow run") && error.message.includes(" with status "))
+    );
+}
+
+async function findActiveWorkflowRunIds(context: CancellationContext) {
+    if (context.graphIds.length === 0) {
+        return [];
+    }
+
+    const fileFilter =
+        context.fileIds && context.fileIds.length > 0
+            ? sql`AND "input"->>'fileId' IN (${textList(context.fileIds)})`
+            : sql``;
+    const workflowNameFilter =
+        context.workflowNames && context.workflowNames.length > 0
+            ? sql`AND "workflow_name" IN (${textList(context.workflowNames)})`
+            : sql``;
+
+    const result = await db.execute(sql<WorkflowRunIdRow>`
+        SELECT "id"
+        FROM openworkflow.workflow_runs
+        WHERE "namespace_id" = ${OPENWORKFLOW_NAMESPACE_ID}
+          AND "status" IN (${textList(ACTIVE_WORKFLOW_STATUSES)})
+          AND "input"->>'graphId' IN (${textList(context.graphIds)})
+          ${fileFilter}
+          ${workflowNameFilter}
+        ORDER BY "created_at" DESC
+    `);
+
+    return [...new Set((result.rows as WorkflowRunIdRow[]).map((row) => row.id))];
+}
+
+async function cancelWorkflowRunIds(workflowRunIds: string[], context: CancellationContext) {
+    let canceledCount = 0;
+    let skippedCount = 0;
+    const failedRunIds: string[] = [];
+
+    for (const workflowRunId of workflowRunIds) {
+        try {
+            await ow.cancelWorkflowRun(workflowRunId);
+            canceledCount += 1;
+        } catch (error) {
+            if (isAlreadyTerminalCancelError(error)) {
+                skippedCount += 1;
+                continue;
+            }
+
+            failedRunIds.push(workflowRunId);
+            logError("failed to cancel workflow run", {
+                workflowRunId,
+                graphIds: context.graphIds,
+                fileIds: context.fileIds,
+                workflowNames: context.workflowNames,
+                error,
+            });
+        }
+    }
+
+    if (failedRunIds.length > 0) {
+        throw new Error(`Failed to cancel ${failedRunIds.length} workflow run(s)`);
+    }
+
+    return {
+        requestedCount: workflowRunIds.length,
+        canceledCount,
+        skippedCount,
+    } satisfies WorkflowCancellationSummary;
+}
+
+async function cancelActiveWorkflowRuns(context: CancellationContext) {
+    const seenWorkflowRunIds = new Set<string>();
+    let canceledCount = 0;
+    let skippedCount = 0;
+
+    for (let pass = 0; pass < MAX_CANCELLATION_PASSES; pass += 1) {
+        const workflowRunIds = await findActiveWorkflowRunIds(context);
+        if (workflowRunIds.length === 0) {
+            return {
+                requestedCount: seenWorkflowRunIds.size,
+                canceledCount,
+                skippedCount,
+            } satisfies WorkflowCancellationSummary;
+        }
+
+        const newWorkflowRunIds = workflowRunIds.filter((workflowRunId) => !seenWorkflowRunIds.has(workflowRunId));
+
+        if (newWorkflowRunIds.length === 0) {
+            throw new Error(`Failed to cancel ${workflowRunIds.length} active workflow run(s)`);
+        }
+
+        for (const workflowRunId of newWorkflowRunIds) {
+            seenWorkflowRunIds.add(workflowRunId);
+        }
+
+        const summary = await cancelWorkflowRunIds(newWorkflowRunIds, context);
+        canceledCount += summary.canceledCount;
+        skippedCount += summary.skippedCount;
+    }
+
+    const remainingWorkflowRunIds = await findActiveWorkflowRunIds(context);
+    if (remainingWorkflowRunIds.length > 0) {
+        throw new Error(`Failed to cancel ${remainingWorkflowRunIds.length} active workflow run(s)`);
+    }
+
+    return {
+        requestedCount: seenWorkflowRunIds.size,
+        canceledCount,
+        skippedCount,
+    } satisfies WorkflowCancellationSummary;
+}
+
+export async function cancelActiveGraphWorkflowRuns(graphIds: string[]) {
+    return cancelActiveWorkflowRuns({ graphIds });
+}
+
+export async function cancelActiveFileProcessingWorkflowRuns(graphId: string, fileIds: string[]) {
+    if (fileIds.length === 0) {
+        return {
+            requestedCount: 0,
+            canceledCount: 0,
+            skippedCount: 0,
+        } satisfies WorkflowCancellationSummary;
+    }
+
+    return cancelActiveWorkflowRuns({
+        graphIds: [graphId],
+        fileIds,
+        workflowNames: ["process-file"],
+    });
+}

--- a/apps/api/src/routes/graph.ts
+++ b/apps/api/src/routes/graph.ts
@@ -20,6 +20,7 @@ import { env } from "../env";
 import { chunk } from "../lib/array";
 import { collectGraphClosure } from "../lib/graph";
 import { mapUnitError } from "../lib/unit";
+import { cancelActiveFileProcessingWorkflowRuns, cancelActiveGraphWorkflowRuns } from "../lib/workflow-cancellation";
 import {
     assertCanCreateUnderParentGraph,
     assertCanPatchGraph,
@@ -1211,10 +1212,22 @@ export const graphRoute = new Elysia({ prefix: "/graphs" })
             }
 
             try {
+                const fileIds = fileKeys.map((fileKey) => fileIdByKey.get(fileKey)!);
                 const handle = await ow.runWorkflow(deleteGraphFilesSpec, {
                     graphId: existingGraph.id,
-                    fileIds: fileKeys.map((fileKey) => fileIdByKey.get(fileKey)!),
+                    fileIds,
                 });
+                const cancellationResult = await Result.tryPromise(async () =>
+                    cancelActiveFileProcessingWorkflowRuns(existingGraph.id, fileIds)
+                );
+                if (cancellationResult.isErr()) {
+                    logError("graph file processing workflow cancellation failed after delete enqueue", {
+                        graphId: existingGraph.id,
+                        removedFileCount: fileKeys.length,
+                        workflowRunId: handle.workflowRun.id,
+                        error: cancellationResult.error,
+                    });
+                }
 
                 return status(200, {
                     status: "success",
@@ -1279,6 +1292,32 @@ export const graphRoute = new Elysia({ prefix: "/graphs" })
             );
             if (accessResult.isErr()) {
                 return mapGraphError(status, accessResult.error);
+            }
+
+            const graphIdsResult = await Result.tryPromise(async () => collectGraphClosure(db, [params.id]));
+            if (graphIdsResult.isErr()) {
+                return status(500, {
+                    status: "error",
+                    message: "Internal server error",
+                    code: "INTERNAL_SERVER_ERROR",
+                });
+            }
+
+            const cancellationResult = await Result.tryPromise(async () =>
+                cancelActiveGraphWorkflowRuns(graphIdsResult.value)
+            );
+            if (cancellationResult.isErr()) {
+                logError("graph workflow cancellation failed before graph delete", {
+                    graphId: params.id,
+                    graphCount: graphIdsResult.value.length,
+                    error: cancellationResult.error,
+                });
+
+                return status(500, {
+                    status: "error",
+                    message: "Internal server error",
+                    code: "INTERNAL_SERVER_ERROR",
+                });
             }
 
             let deleteResult: {


### PR DESCRIPTION
## Summary

Cancel active OpenWorkflow runs before deleting graphs or files so background processing does not continue against removed data.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Added workflow cancellation helpers that find active OpenWorkflow runs by `graphId` and optional `fileId`, then cancel them via `ow.cancelWorkflowRun`.
- Cancel all active workflows for a graph closure before graph deletion, and cancel active `process-file` runs after enqueueing file deletion workflows.

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation as needed
- [x] I have run `make generate` if SQL queries were modified (backend)
- [x] I have updated barrel exports if components were added (frontend)