### PR TITLE
fix: disable reset chat button when chat is empty

### DIFF
--- a/apps/frontend/components/chat/ProjectChat.tsx
+++ b/apps/frontend/components/chat/ProjectChat.tsx
@@ -708,7 +708,7 @@ function ProjectChatSession({
                             variant="outline"
                             size="icon"
                             onClick={() => setIsResetDialogOpen(true)}
-                            disabled={isAssistantTyping || messages.length === 0}
+                            disabled={isAssistantTyping || displayedMessages.length === 0}
                             aria-label={t("reset.chat")}
                             className="h-8 w-8"
                         >

--- a/apps/frontend/components/chat/ProjectChat.tsx
+++ b/apps/frontend/components/chat/ProjectChat.tsx
@@ -708,7 +708,7 @@ function ProjectChatSession({
                             variant="outline"
                             size="icon"
                             onClick={() => setIsResetDialogOpen(true)}
-                            disabled={isAssistantTyping}
+                            disabled={isAssistantTyping || messages.length === 0}
                             aria-label={t("reset.chat")}
                             className="h-8 w-8"
                         >


### PR DESCRIPTION
## Summary

Disables the reset chat button when the chat has no messages, preventing a `CHAT_NOT_FOUND` API error when trying to delete a chat that was never persisted to the database.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Changes Made

- Disabled the reset chat button when `messages.length === 0` in `ProjectChat.tsx`

## Related Issues

Closes #289

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation as needed
- [ ] I have run `make generate` if SQL queries were modified (backend)
- [ ] I have updated barrel exports if components were added (frontend)